### PR TITLE
PHPUnit to Pest Converter

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,4 +70,4 @@ jobs:
           composer update --${{ matrix.version }} --prefer-dist --no-interaction
 
       - name: Execute tests
-        run: vendor/bin/phpunit
+        run: vendor/bin/pest

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "nesbot/carbon": "^2.63|^3.0",
         "orchestra/testbench": "^8.0|^9.0|^10.0",
         "php-http/discovery": "^1.12",
-        "phpunit/phpunit": "^10.0|^11.0"
+        "pestphp/pest": "^2.2"
     },
     "config": {
         "allow-plugins": {

--- a/tests/Actions/CreatesIndexTest.php
+++ b/tests/Actions/CreatesIndexTest.php
@@ -2,92 +2,79 @@
 
 declare(strict_types=1);
 
-namespace Dwarf\MeiliTools\Tests\Actions;
-
 use Dwarf\MeiliTools\Contracts\Actions\CreatesIndex;
 use Dwarf\MeiliTools\Exceptions\MeiliToolsException;
 use Dwarf\MeiliTools\Tests\TestCase;
 use Illuminate\Testing\Fluent\AssertableJson;
 use MeiliSearch\Exceptions\CommunicationException;
 
+uses(Dwarf\MeiliTools\Tests\TestCase::class);
+
 /**
  * @internal
  */
-class CreatesIndexTest extends TestCase
-{
-    /**
-     * Test index.
-     *
-     * @var string
-     */
-    private const INDEX = 'testing-creates-index';
 
-    /**
-     * Test using wrong Scout driver.
-     */
-    public function test_meili_tools_exception(): void
-    {
-        config(['scout.driver' => null]);
+/**
+ * Test using wrong Scout driver.
+ */
+test('meili tools exception', function () {
+    config(['scout.driver' => null]);
 
-        $this->expectException(MeiliToolsException::class);
+    $this->expectException(MeiliToolsException::class);
 
-        $action = $this->app->make(CreatesIndex::class);
+    $action = app()->make(CreatesIndex::class);
+    $info = ($action)(self::INDEX);
+});
+
+/**
+ * Test creating index when MeiliSearch isn't running.
+ */
+test('communication exception', function () {
+    config(['scout.meilisearch.host' => 'http://localhost:7777']);
+
+    $this->expectException(CommunicationException::class);
+    $this->expectExceptionMessage('Failed to connect to localhost port 7777');
+
+    $action = app()->make(CreatesIndex::class);
+    $info = ($action)(self::INDEX);
+});
+
+/**
+ * Test CreatesIndex::__invoke() method.
+ */
+test('invoke', function () {
+    try {
+        $action = app()->make(CreatesIndex::class);
         $info = ($action)(self::INDEX);
+
+        AssertableJson::fromArray($info)
+            ->where('uid', self::INDEX)
+            ->where('primaryKey', null)
+            ->whereType('createdAt', 'string')
+            ->whereType('updatedAt', 'string')
+            ->interacted()
+        ;
+    } finally {
+        $this->deleteIndex(self::INDEX);
     }
+});
 
-    /**
-     * Test creating index when MeiliSearch isn't running.
-     */
-    public function test_communication_exception(): void
-    {
-        config(['scout.meilisearch.host' => 'http://localhost:7777']);
+/**
+ * Test CreatesIndex::__invoke() method with options.
+ */
+test('invoke with options', function () {
+    try {
+        $action = app()->make(CreatesIndex::class);
+        $info = ($action)(self::INDEX, ['primaryKey' => 'id']);
 
-        $this->expectException(CommunicationException::class);
-        $this->expectExceptionMessage('Failed to connect to localhost port 7777');
-
-        $action = $this->app->make(CreatesIndex::class);
-        $info = ($action)(self::INDEX);
+        AssertableJson::fromArray($info)
+            ->where('uid', self::INDEX)
+            ->where('primaryKey', 'id')
+            ->whereType('createdAt', 'string')
+            ->whereType('updatedAt', 'string')
+            ->interacted()
+        ;
+    } finally {
+        $this->deleteIndex(self::INDEX);
     }
-
-    /**
-     * Test CreatesIndex::__invoke() method.
-     */
-    public function test_invoke(): void
-    {
-        try {
-            $action = $this->app->make(CreatesIndex::class);
-            $info = ($action)(self::INDEX);
-
-            AssertableJson::fromArray($info)
-                ->where('uid', self::INDEX)
-                ->where('primaryKey', null)
-                ->whereType('createdAt', 'string')
-                ->whereType('updatedAt', 'string')
-                ->interacted()
-            ;
-        } finally {
-            $this->deleteIndex(self::INDEX);
-        }
-    }
-
-    /**
-     * Test CreatesIndex::__invoke() method with options.
-     */
-    public function test_invoke_with_options(): void
-    {
-        try {
-            $action = $this->app->make(CreatesIndex::class);
-            $info = ($action)(self::INDEX, ['primaryKey' => 'id']);
-
-            AssertableJson::fromArray($info)
-                ->where('uid', self::INDEX)
-                ->where('primaryKey', 'id')
-                ->whereType('createdAt', 'string')
-                ->whereType('updatedAt', 'string')
-                ->interacted()
-            ;
-        } finally {
-            $this->deleteIndex(self::INDEX);
-        }
-    }
-}
+});

--- a/tests/Actions/CreatesIndexTest.php
+++ b/tests/Actions/CreatesIndexTest.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 use Dwarf\MeiliTools\Contracts\Actions\CreatesIndex;
 use Dwarf\MeiliTools\Exceptions\MeiliToolsException;
-use Dwarf\MeiliTools\Tests\TestCase;
 use Illuminate\Testing\Fluent\AssertableJson;
 use MeiliSearch\Exceptions\CommunicationException;
-
 
 /**
  * @internal

--- a/tests/Actions/CreatesIndexTest.php
+++ b/tests/Actions/CreatesIndexTest.php
@@ -8,7 +8,6 @@ use Dwarf\MeiliTools\Tests\TestCase;
 use Illuminate\Testing\Fluent\AssertableJson;
 use MeiliSearch\Exceptions\CommunicationException;
 
-uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal

--- a/tests/Actions/DeletesIndexTest.php
+++ b/tests/Actions/DeletesIndexTest.php
@@ -2,69 +2,56 @@
 
 declare(strict_types=1);
 
-namespace Dwarf\MeiliTools\Tests\Actions;
-
 use Dwarf\MeiliTools\Contracts\Actions\DeletesIndex;
 use Dwarf\MeiliTools\Exceptions\MeiliToolsException;
 use Dwarf\MeiliTools\Tests\TestCase;
 use MeiliSearch\Exceptions\CommunicationException;
 
+uses(Dwarf\MeiliTools\Tests\TestCase::class);
+
 /**
  * @internal
  */
-class DeletesIndexTest extends TestCase
-{
-    /**
-     * Test index.
-     *
-     * @var string
-     */
-    private const INDEX = 'testing-deletes-index';
 
-    /**
-     * Test using wrong Scout driver.
-     */
-    public function test_meili_tools_exception(): void
-    {
-        config(['scout.driver' => null]);
+/**
+ * Test using wrong Scout driver.
+ */
+test('meili tools exception', function () {
+    config(['scout.driver' => null]);
 
-        $this->expectException(MeiliToolsException::class);
+    $this->expectException(MeiliToolsException::class);
 
-        $action = $this->app->make(DeletesIndex::class);
-        $delete = ($action)(self::INDEX);
-    }
+    $action = app()->make(DeletesIndex::class);
+    $delete = ($action)(self::INDEX);
+});
 
-    /**
-     * Test deleting index when MeiliSearch isn't running.
-     */
-    public function test_communication_exception(): void
-    {
-        config(['scout.meilisearch.host' => 'http://localhost:7777']);
+/**
+ * Test deleting index when MeiliSearch isn't running.
+ */
+test('communication exception', function () {
+    config(['scout.meilisearch.host' => 'http://localhost:7777']);
 
-        $this->expectException(CommunicationException::class);
-        $this->expectExceptionMessage('Failed to connect to localhost port 7777');
+    $this->expectException(CommunicationException::class);
+    $this->expectExceptionMessage('Failed to connect to localhost port 7777');
 
-        $action = $this->app->make(DeletesIndex::class);
-        ($action)(self::INDEX);
-    }
+    $action = app()->make(DeletesIndex::class);
+    ($action)(self::INDEX);
+});
 
-    /**
-     * Test deleting index when it doesn't exist.
-     */
-    public function test_index_missing(): void
-    {
-        // No errors will be thrown in this case.
-        $action = $this->app->make(DeletesIndex::class);
-        ($action)(self::INDEX);
-    }
+/**
+ * Test deleting index when it doesn't exist.
+ */
+test('index missing', function () {
+    // No errors will be thrown in this case.
+    $action = app()->make(DeletesIndex::class);
+    ($action)(self::INDEX);
+});
 
-    /**
-     * Test DeletesIndex::__invoke() method.
-     */
-    public function test_invoke(): void
-    {
-        $this->createIndex(self::INDEX);
-        $action = $this->app->make(DeletesIndex::class);
-        ($action)(self::INDEX);
-    }
-}
+/**
+ * Test DeletesIndex::__invoke() method.
+ */
+test('invoke', function () {
+    $this->createIndex(self::INDEX);
+    $action = app()->make(DeletesIndex::class);
+    ($action)(self::INDEX);
+});

--- a/tests/Actions/DeletesIndexTest.php
+++ b/tests/Actions/DeletesIndexTest.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 use Dwarf\MeiliTools\Contracts\Actions\DeletesIndex;
 use Dwarf\MeiliTools\Exceptions\MeiliToolsException;
-use Dwarf\MeiliTools\Tests\TestCase;
 use MeiliSearch\Exceptions\CommunicationException;
-
 
 /**
  * @internal

--- a/tests/Actions/DeletesIndexTest.php
+++ b/tests/Actions/DeletesIndexTest.php
@@ -7,7 +7,6 @@ use Dwarf\MeiliTools\Exceptions\MeiliToolsException;
 use Dwarf\MeiliTools\Tests\TestCase;
 use MeiliSearch\Exceptions\CommunicationException;
 
-uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal

--- a/tests/Actions/DetailsIndexTest.php
+++ b/tests/Actions/DetailsIndexTest.php
@@ -5,10 +5,8 @@ declare(strict_types=1);
 use Dwarf\MeiliTools\Contracts\Actions\DetailsIndex;
 use Dwarf\MeiliTools\Exceptions\MeiliToolsException;
 use Dwarf\MeiliTools\Helpers;
-use Dwarf\MeiliTools\Tests\TestCase;
 use MeiliSearch\Exceptions\ApiException;
 use MeiliSearch\Exceptions\CommunicationException;
-
 
 /**
  * @internal

--- a/tests/Actions/DetailsIndexTest.php
+++ b/tests/Actions/DetailsIndexTest.php
@@ -58,6 +58,6 @@ test('invoke', function () {
     $this->withIndex(self::INDEX, function () {
         $action = app()->make(DetailsIndex::class);
         $details = ($action)(self::INDEX);
-        $this->assertSame(Helpers::defaultSettings(Helpers::engineVersion()), $details);
+        expect($details)->toBe(Helpers::defaultSettings(Helpers::engineVersion()));
     });
 });

--- a/tests/Actions/DetailsIndexTest.php
+++ b/tests/Actions/DetailsIndexTest.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-namespace Dwarf\MeiliTools\Tests\Actions;
-
 use Dwarf\MeiliTools\Contracts\Actions\DetailsIndex;
 use Dwarf\MeiliTools\Exceptions\MeiliToolsException;
 use Dwarf\MeiliTools\Helpers;
@@ -11,66 +9,55 @@ use Dwarf\MeiliTools\Tests\TestCase;
 use MeiliSearch\Exceptions\ApiException;
 use MeiliSearch\Exceptions\CommunicationException;
 
+uses(Dwarf\MeiliTools\Tests\TestCase::class);
+
 /**
  * @internal
  */
-class DetailsIndexTest extends TestCase
-{
-    /**
-     * Test index.
-     *
-     * @var string
-     */
-    private const INDEX = 'testing-details-index';
 
-    /**
-     * Test using wrong Scout driver.
-     */
-    public function test_meili_tools_exception(): void
-    {
-        config(['scout.driver' => null]);
+/**
+ * Test using wrong Scout driver.
+ */
+test('meili tools exception', function () {
+    config(['scout.driver' => null]);
 
-        $this->expectException(MeiliToolsException::class);
+    $this->expectException(MeiliToolsException::class);
 
-        $action = $this->app->make(DetailsIndex::class);
+    $action = app()->make(DetailsIndex::class);
+    $details = ($action)(self::INDEX);
+});
+
+/**
+ * Test getting index details when MeiliSearch isn't running.
+ */
+test('communication exception', function () {
+    config(['scout.meilisearch.host' => 'http://localhost:7777']);
+
+    $this->expectException(CommunicationException::class);
+    $this->expectExceptionMessage('Failed to connect to localhost port 7777');
+
+    $action = app()->make(DetailsIndex::class);
+    $details = ($action)(self::INDEX);
+});
+
+/**
+ * Test getting index details when it doesn't exist.
+ */
+test('api exception', function () {
+    $this->expectException(ApiException::class);
+    $this->expectExceptionMessage('Index `' . self::INDEX . '` not found.');
+
+    $action = app()->make(DetailsIndex::class);
+    $details = ($action)(self::INDEX);
+});
+
+/**
+ * Test DetailsIndex::__invoke() method.
+ */
+test('invoke', function () {
+    $this->withIndex(self::INDEX, function () {
+        $action = app()->make(DetailsIndex::class);
         $details = ($action)(self::INDEX);
-    }
-
-    /**
-     * Test getting index details when MeiliSearch isn't running.
-     */
-    public function test_communication_exception(): void
-    {
-        config(['scout.meilisearch.host' => 'http://localhost:7777']);
-
-        $this->expectException(CommunicationException::class);
-        $this->expectExceptionMessage('Failed to connect to localhost port 7777');
-
-        $action = $this->app->make(DetailsIndex::class);
-        $details = ($action)(self::INDEX);
-    }
-
-    /**
-     * Test getting index details when it doesn't exist.
-     */
-    public function test_api_exception(): void
-    {
-        $this->expectException(ApiException::class);
-        $this->expectExceptionMessage('Index `' . self::INDEX . '` not found.');
-
-        $action = $this->app->make(DetailsIndex::class);
-        $details = ($action)(self::INDEX);
-    }
-
-    /**
-     * Test DetailsIndex::__invoke() method.
-     */
-    public function test_invoke(): void
-    {
-        $this->withIndex(self::INDEX, function () {
-            $action = $this->app->make(DetailsIndex::class);
-            $details = ($action)(self::INDEX);
-            $this->assertSame(Helpers::defaultSettings(Helpers::engineVersion()), $details);
-        });
-    }
-}
+        $this->assertSame(Helpers::defaultSettings(Helpers::engineVersion()), $details);
+    });
+});

--- a/tests/Actions/DetailsIndexTest.php
+++ b/tests/Actions/DetailsIndexTest.php
@@ -9,7 +9,6 @@ use Dwarf\MeiliTools\Tests\TestCase;
 use MeiliSearch\Exceptions\ApiException;
 use MeiliSearch\Exceptions\CommunicationException;
 
-uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal

--- a/tests/Actions/DetailsModelTest.php
+++ b/tests/Actions/DetailsModelTest.php
@@ -2,28 +2,25 @@
 
 declare(strict_types=1);
 
-namespace Dwarf\MeiliTools\Tests\Actions;
-
 use Dwarf\MeiliTools\Contracts\Actions\DetailsModel;
 use Dwarf\MeiliTools\Helpers;
 use Dwarf\MeiliTools\Tests\Models\Movie;
 use Dwarf\MeiliTools\Tests\TestCase;
 
+uses(Dwarf\MeiliTools\Tests\TestCase::class);
+
 /**
  * @internal
  */
-class DetailsModelTest extends TestCase
-{
-    /**
-     * Test DetailsModel::__invoke() method.
-     */
-    public function test_invoke(): void
-    {
-        try {
-            $details = $this->app->make(DetailsModel::class)(Movie::class);
-            $this->assertSame(Helpers::defaultSettings(Helpers::engineVersion()), $details);
-        } finally {
-            $this->deleteIndex(app(Movie::class)->searchableAs());
-        }
+
+/**
+ * Test DetailsModel::__invoke() method.
+ */
+test('invoke', function () {
+    try {
+        $details = app()->make(DetailsModel::class)(Movie::class);
+        $this->assertSame(Helpers::defaultSettings(Helpers::engineVersion()), $details);
+    } finally {
+        $this->deleteIndex(app(Movie::class)->searchableAs());
     }
-}
+});

--- a/tests/Actions/DetailsModelTest.php
+++ b/tests/Actions/DetailsModelTest.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 use Dwarf\MeiliTools\Contracts\Actions\DetailsModel;
 use Dwarf\MeiliTools\Helpers;
 use Dwarf\MeiliTools\Tests\Models\Movie;
-use Dwarf\MeiliTools\Tests\TestCase;
-
 
 /**
  * @internal

--- a/tests/Actions/DetailsModelTest.php
+++ b/tests/Actions/DetailsModelTest.php
@@ -19,7 +19,7 @@ uses(Dwarf\MeiliTools\Tests\TestCase::class);
 test('invoke', function () {
     try {
         $details = app()->make(DetailsModel::class)(Movie::class);
-        $this->assertSame(Helpers::defaultSettings(Helpers::engineVersion()), $details);
+        expect($details)->toBe(Helpers::defaultSettings(Helpers::engineVersion()));
     } finally {
         $this->deleteIndex(app(Movie::class)->searchableAs());
     }

--- a/tests/Actions/DetailsModelTest.php
+++ b/tests/Actions/DetailsModelTest.php
@@ -7,7 +7,6 @@ use Dwarf\MeiliTools\Helpers;
 use Dwarf\MeiliTools\Tests\Models\Movie;
 use Dwarf\MeiliTools\Tests\TestCase;
 
-uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal

--- a/tests/Actions/EnsuresIndexExistsTest.php
+++ b/tests/Actions/EnsuresIndexExistsTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 use Dwarf\MeiliTools\Contracts\Actions\EnsuresIndexExists;
 use Dwarf\MeiliTools\Exceptions\MeiliToolsException;
-use Dwarf\MeiliTools\Tests\TestCase;
-
 
 /**
  * @internal

--- a/tests/Actions/EnsuresIndexExistsTest.php
+++ b/tests/Actions/EnsuresIndexExistsTest.php
@@ -6,7 +6,6 @@ use Dwarf\MeiliTools\Contracts\Actions\EnsuresIndexExists;
 use Dwarf\MeiliTools\Exceptions\MeiliToolsException;
 use Dwarf\MeiliTools\Tests\TestCase;
 
-uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal

--- a/tests/Actions/EnsuresIndexExistsTest.php
+++ b/tests/Actions/EnsuresIndexExistsTest.php
@@ -2,48 +2,37 @@
 
 declare(strict_types=1);
 
-namespace Dwarf\MeiliTools\Tests\Actions;
-
 use Dwarf\MeiliTools\Contracts\Actions\EnsuresIndexExists;
 use Dwarf\MeiliTools\Exceptions\MeiliToolsException;
 use Dwarf\MeiliTools\Tests\TestCase;
 
+uses(Dwarf\MeiliTools\Tests\TestCase::class);
+
 /**
  * @internal
  */
-class EnsuresIndexExistsTest extends TestCase
-{
-    /**
-     * Test index.
-     *
-     * @var string
-     */
-    private const INDEX = 'testing-ensures-index';
 
-    /**
-     * Test using wrong Scout driver.
-     */
-    public function test_meili_tools_exception(): void
-    {
-        config(['scout.driver' => null]);
+/**
+ * Test using wrong Scout driver.
+ */
+test('meili tools exception', function () {
+    config(['scout.driver' => null]);
 
-        $this->expectException(MeiliToolsException::class);
+    $this->expectException(MeiliToolsException::class);
 
-        $action = $this->app->make(EnsuresIndexExists::class);
-        $details = ($action)(self::INDEX);
+    $action = app()->make(EnsuresIndexExists::class);
+    $details = ($action)(self::INDEX);
+});
+
+/**
+ * Test EnsuresIndexExists::__invoke() method.
+ *
+ * @doesNotPerformAssertions
+ */
+test('invoke', function () {
+    try {
+        app()->make(EnsuresIndexExists::class)(self::INDEX);
+    } finally {
+        $this->deleteIndex(self::INDEX);
     }
-
-    /**
-     * Test EnsuresIndexExists::__invoke() method.
-     *
-     * @doesNotPerformAssertions
-     */
-    public function test_invoke(): void
-    {
-        try {
-            $this->app->make(EnsuresIndexExists::class)(self::INDEX);
-        } finally {
-            $this->deleteIndex(self::INDEX);
-        }
-    }
-}
+});

--- a/tests/Actions/ListsClassesTest.php
+++ b/tests/Actions/ListsClassesTest.php
@@ -2,39 +2,36 @@
 
 declare(strict_types=1);
 
-namespace Dwarf\MeiliTools\Tests\Actions;
-
 use Dwarf\MeiliTools\Contracts\Actions\ListsClasses;
 use Dwarf\MeiliTools\Contracts\Indexes\MeiliSettings;
 use Dwarf\MeiliTools\Tests\TestCase;
 
+uses(Dwarf\MeiliTools\Tests\TestCase::class);
+
 /**
  * @internal
  */
-class ListsClassesTest extends TestCase
-{
-    /**
-     * Test listing models using absolute and relative paths.
-     */
-    public function test_path_listing(): void
-    {
-        $action = $this->app->make(ListsClasses::class);
 
-        $path = 'app/Models';
-        $namespace = 'App\\Models';
-        $classes = $action($path, $namespace);
-        $this->assertCount(0, $classes);
+/**
+ * Test listing models using absolute and relative paths.
+ */
+test('path listing', function () {
+    $action = app()->make(ListsClasses::class);
 
-        $path = base_path($path);
-        $classes = $action($path, $namespace);
-        $this->assertCount(0, $classes);
+    $path = 'app/Models';
+    $namespace = 'App\\Models';
+    $classes = $action($path, $namespace);
+    $this->assertCount(0, $classes);
 
-        $path = __DIR__ . '/../Models';
-        $namespace = 'Dwarf\\MeiliTools\\Tests\\Models';
-        $classes = $action($path, $namespace);
-        $this->assertCount(3, $classes);
+    $path = base_path($path);
+    $classes = $action($path, $namespace);
+    $this->assertCount(0, $classes);
 
-        $classes = $action($path, $namespace, fn ($class) => is_a($class, MeiliSettings::class, true));
-        $this->assertCount(2, $classes);
-    }
-}
+    $path = __DIR__ . '/../Models';
+    $namespace = 'Dwarf\\MeiliTools\\Tests\\Models';
+    $classes = $action($path, $namespace);
+    $this->assertCount(3, $classes);
+
+    $classes = $action($path, $namespace, fn ($class) => is_a($class, MeiliSettings::class, true));
+    $this->assertCount(2, $classes);
+});

--- a/tests/Actions/ListsClassesTest.php
+++ b/tests/Actions/ListsClassesTest.php
@@ -21,17 +21,17 @@ test('path listing', function () {
     $path = 'app/Models';
     $namespace = 'App\\Models';
     $classes = $action($path, $namespace);
-    $this->assertCount(0, $classes);
+    expect($classes)->toHaveCount(0);
 
     $path = base_path($path);
     $classes = $action($path, $namespace);
-    $this->assertCount(0, $classes);
+    expect($classes)->toHaveCount(0);
 
     $path = __DIR__ . '/../Models';
     $namespace = 'Dwarf\\MeiliTools\\Tests\\Models';
     $classes = $action($path, $namespace);
-    $this->assertCount(3, $classes);
+    expect($classes)->toHaveCount(3);
 
     $classes = $action($path, $namespace, fn ($class) => is_a($class, MeiliSettings::class, true));
-    $this->assertCount(2, $classes);
+    expect($classes)->toHaveCount(2);
 });

--- a/tests/Actions/ListsClassesTest.php
+++ b/tests/Actions/ListsClassesTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 use Dwarf\MeiliTools\Contracts\Actions\ListsClasses;
 use Dwarf\MeiliTools\Contracts\Indexes\MeiliSettings;
-use Dwarf\MeiliTools\Tests\TestCase;
-
 
 /**
  * @internal

--- a/tests/Actions/ListsClassesTest.php
+++ b/tests/Actions/ListsClassesTest.php
@@ -6,7 +6,6 @@ use Dwarf\MeiliTools\Contracts\Actions\ListsClasses;
 use Dwarf\MeiliTools\Contracts\Indexes\MeiliSettings;
 use Dwarf\MeiliTools\Tests\TestCase;
 
-uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal

--- a/tests/Actions/ListsIndexesTest.php
+++ b/tests/Actions/ListsIndexesTest.php
@@ -2,93 +2,80 @@
 
 declare(strict_types=1);
 
-namespace Dwarf\MeiliTools\Tests\Actions;
-
 use Dwarf\MeiliTools\Contracts\Actions\ListsIndexes;
 use Dwarf\MeiliTools\Exceptions\MeiliToolsException;
 use Dwarf\MeiliTools\Tests\TestCase;
 use Illuminate\Testing\Fluent\AssertableJson;
 use MeiliSearch\Exceptions\CommunicationException;
 
+uses(Dwarf\MeiliTools\Tests\TestCase::class);
+
 /**
  * @internal
  */
-class ListsIndexesTest extends TestCase
-{
-    /**
-     * Test index.
-     *
-     * @var string
-     */
-    private const INDEX = 'testing-indexes-list';
 
-    /**
-     * Test using wrong Scout driver.
-     */
-    public function test_meili_tools_exception(): void
-    {
-        config(['scout.driver' => null]);
+/**
+ * Test using wrong Scout driver.
+ */
+test('meili tools exception', function () {
+    config(['scout.driver' => null]);
 
-        $this->expectException(MeiliToolsException::class);
+    $this->expectException(MeiliToolsException::class);
 
-        $action = $this->app->make(ListsIndexes::class);
+    $action = app()->make(ListsIndexes::class);
+    $list = ($action)();
+});
+
+/**
+ * Test getting index list when MeiliSearch isn't running.
+ */
+test('communication exception', function () {
+    config(['scout.meilisearch.host' => 'http://localhost:7777']);
+
+    $this->expectException(CommunicationException::class);
+    $this->expectExceptionMessage('Failed to connect to localhost port 7777');
+
+    $action = app()->make(ListsIndexes::class);
+    $list = ($action)();
+});
+
+/**
+ * Test ListsIndexes::__invoke() method.
+ */
+test('invoke', function () {
+    $this->withIndex(self::INDEX, function () {
+        $action = app()->make(ListsIndexes::class);
         $list = ($action)();
-    }
 
-    /**
-     * Test getting index list when MeiliSearch isn't running.
-     */
-    public function test_communication_exception(): void
-    {
-        config(['scout.meilisearch.host' => 'http://localhost:7777']);
+        $this->assertArrayHasKey(self::INDEX, $list);
+        AssertableJson::fromArray($list[self::INDEX])
+            ->where('uid', self::INDEX)
+            ->where('primaryKey', null)
+            ->whereType('createdAt', 'string')
+            ->whereType('updatedAt', 'string')
+            ->interacted()
+        ;
+    });
+});
 
-        $this->expectException(CommunicationException::class);
-        $this->expectExceptionMessage('Failed to connect to localhost port 7777');
+/**
+ * Test ListsIndexes::__invoke() method with stats.
+ */
+test('invoke with stats', function () {
+    $this->withIndex(self::INDEX, function () {
+        $action = app()->make(ListsIndexes::class);
+        $list = ($action)(true);
 
-        $action = $this->app->make(ListsIndexes::class);
-        $list = ($action)();
-    }
-
-    /**
-     * Test ListsIndexes::__invoke() method.
-     */
-    public function test_invoke(): void
-    {
-        $this->withIndex(self::INDEX, function () {
-            $action = $this->app->make(ListsIndexes::class);
-            $list = ($action)();
-
-            $this->assertArrayHasKey(self::INDEX, $list);
-            AssertableJson::fromArray($list[self::INDEX])
-                ->where('uid', self::INDEX)
-                ->where('primaryKey', null)
-                ->whereType('createdAt', 'string')
-                ->whereType('updatedAt', 'string')
-                ->interacted()
-            ;
-        });
-    }
-
-    /**
-     * Test ListsIndexes::__invoke() method with stats.
-     */
-    public function test_invoke_with_stats(): void
-    {
-        $this->withIndex(self::INDEX, function () {
-            $action = $this->app->make(ListsIndexes::class);
-            $list = ($action)(true);
-
-            $this->assertArrayHasKey(self::INDEX, $list);
-            AssertableJson::fromArray($list[self::INDEX])
-                ->where('uid', self::INDEX)
-                ->where('primaryKey', null)
-                ->whereType('createdAt', 'string')
-                ->whereType('updatedAt', 'string')
-                ->where('numberOfDocuments', 0)
-                ->where('isIndexing', false)
-                ->etc()
-                ->interacted()
-            ;
-        });
-    }
-}
+        $this->assertArrayHasKey(self::INDEX, $list);
+        AssertableJson::fromArray($list[self::INDEX])
+            ->where('uid', self::INDEX)
+            ->where('primaryKey', null)
+            ->whereType('createdAt', 'string')
+            ->whereType('updatedAt', 'string')
+            ->where('numberOfDocuments', 0)
+            ->where('isIndexing', false)
+            ->etc()
+            ->interacted()
+        ;
+    });
+});

--- a/tests/Actions/ListsIndexesTest.php
+++ b/tests/Actions/ListsIndexesTest.php
@@ -8,7 +8,6 @@ use Dwarf\MeiliTools\Tests\TestCase;
 use Illuminate\Testing\Fluent\AssertableJson;
 use MeiliSearch\Exceptions\CommunicationException;
 
-uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal

--- a/tests/Actions/ListsIndexesTest.php
+++ b/tests/Actions/ListsIndexesTest.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 use Dwarf\MeiliTools\Contracts\Actions\ListsIndexes;
 use Dwarf\MeiliTools\Exceptions\MeiliToolsException;
-use Dwarf\MeiliTools\Tests\TestCase;
 use Illuminate\Testing\Fluent\AssertableJson;
 use MeiliSearch\Exceptions\CommunicationException;
-
 
 /**
  * @internal

--- a/tests/Actions/ResetsIndexTest.php
+++ b/tests/Actions/ResetsIndexTest.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-namespace Dwarf\MeiliTools\Tests\Actions;
-
 use Dwarf\MeiliTools\Contracts\Actions\DetailsIndex;
 use Dwarf\MeiliTools\Contracts\Actions\ResetsIndex;
 use Dwarf\MeiliTools\Contracts\Actions\SynchronizesIndex;
@@ -11,71 +9,62 @@ use Dwarf\MeiliTools\Helpers;
 use Dwarf\MeiliTools\Tests\TestCase;
 use Dwarf\MeiliTools\Tests\Tools;
 
+uses(Dwarf\MeiliTools\Tests\TestCase::class);
+
 /**
  * @internal
  */
-class ResetsIndexTest extends TestCase
-{
-    /**
-     * Test index.
-     *
-     * @var string
-     */
-    private const INDEX = 'testing-resets-index';
 
-    /**
-     * Test ResetsIndex::__invoke() method with movie settings.
-     */
-    public function test_with_movie_settings(): void
-    {
-        $this->withIndex(self::INDEX, function () {
-            $defaults = Helpers::defaultSettings(Helpers::engineVersion());
-            $settings = Tools::movieSettings();
+/**
+ * Test ResetsIndex::__invoke() method with movie settings.
+ */
+test('with movie settings', function () {
+    $this->withIndex(self::INDEX, function () {
+        $defaults = Helpers::defaultSettings(Helpers::engineVersion());
+        $settings = Tools::movieSettings();
 
-            $this->app->make(SynchronizesIndex::class)(self::INDEX, $settings);
-            $details = $this->app->make(DetailsIndex::class)(self::INDEX);
-            $this->assertNotSame($defaults, $details);
-            $this->assertSame(array_replace($defaults, $settings), $details);
+        app()->make(SynchronizesIndex::class)(self::INDEX, $settings);
+        $details = app()->make(DetailsIndex::class)(self::INDEX);
+        $this->assertNotSame($defaults, $details);
+        $this->assertSame(array_replace($defaults, $settings), $details);
 
-            $changes = $this->app->make(ResetsIndex::class)(self::INDEX);
-            $this->assertCount(8, $changes);
+        $changes = app()->make(ResetsIndex::class)(self::INDEX);
+        $this->assertCount(8, $changes);
 
-            foreach ($changes as $key => $value) {
-                $old = $settings[$key];
-                $new = null;
-                $this->assertSame(compact('old', 'new'), $value);
-            }
+        foreach ($changes as $key => $value) {
+            $old = $settings[$key];
+            $new = null;
+            $this->assertSame(compact('old', 'new'), $value);
+        }
 
-            $details = $this->app->make(DetailsIndex::class)(self::INDEX);
-            $this->assertSame($defaults, $details);
-        });
-    }
+        $details = app()->make(DetailsIndex::class)(self::INDEX);
+        $this->assertSame($defaults, $details);
+    });
+});
 
-    /**
-     * Test ResetsIndex::__invoke() method with pretend.
-     */
-    public function test_with_pretend(): void
-    {
-        $this->withIndex(self::INDEX, function () {
-            $defaults = Helpers::defaultSettings(Helpers::engineVersion());
-            $settings = Tools::movieSettings();
+/**
+ * Test ResetsIndex::__invoke() method with pretend.
+ */
+test('with pretend', function () {
+    $this->withIndex(self::INDEX, function () {
+        $defaults = Helpers::defaultSettings(Helpers::engineVersion());
+        $settings = Tools::movieSettings();
 
-            $this->app->make(SynchronizesIndex::class)(self::INDEX, $settings);
-            $details = $this->app->make(DetailsIndex::class)(self::INDEX);
-            $this->assertNotSame($defaults, $details);
-            $this->assertSame(array_replace($defaults, $settings), $details);
+        app()->make(SynchronizesIndex::class)(self::INDEX, $settings);
+        $details = app()->make(DetailsIndex::class)(self::INDEX);
+        $this->assertNotSame($defaults, $details);
+        $this->assertSame(array_replace($defaults, $settings), $details);
 
-            $changes = $this->app->make(ResetsIndex::class)(self::INDEX, true);
-            $this->assertCount(8, $changes);
+        $changes = app()->make(ResetsIndex::class)(self::INDEX, true);
+        $this->assertCount(8, $changes);
 
-            foreach ($changes as $key => $value) {
-                $old = $settings[$key];
-                $new = null;
-                $this->assertSame(compact('old', 'new'), $value);
-            }
+        foreach ($changes as $key => $value) {
+            $old = $settings[$key];
+            $new = null;
+            $this->assertSame(compact('old', 'new'), $value);
+        }
 
-            $details = $this->app->make(DetailsIndex::class)(self::INDEX);
-            $this->assertNotSame($defaults, $details);
-        });
-    }
-}
+        $details = app()->make(DetailsIndex::class)(self::INDEX);
+        $this->assertNotSame($defaults, $details);
+    });
+});

--- a/tests/Actions/ResetsIndexTest.php
+++ b/tests/Actions/ResetsIndexTest.php
@@ -6,9 +6,7 @@ use Dwarf\MeiliTools\Contracts\Actions\DetailsIndex;
 use Dwarf\MeiliTools\Contracts\Actions\ResetsIndex;
 use Dwarf\MeiliTools\Contracts\Actions\SynchronizesIndex;
 use Dwarf\MeiliTools\Helpers;
-use Dwarf\MeiliTools\Tests\TestCase;
 use Dwarf\MeiliTools\Tests\Tools;
-
 
 /**
  * @internal

--- a/tests/Actions/ResetsIndexTest.php
+++ b/tests/Actions/ResetsIndexTest.php
@@ -26,19 +26,19 @@ test('with movie settings', function () {
         app()->make(SynchronizesIndex::class)(self::INDEX, $settings);
         $details = app()->make(DetailsIndex::class)(self::INDEX);
         $this->assertNotSame($defaults, $details);
-        $this->assertSame(array_replace($defaults, $settings), $details);
+        expect($details)->toBe(array_replace($defaults, $settings));
 
         $changes = app()->make(ResetsIndex::class)(self::INDEX);
-        $this->assertCount(8, $changes);
+        expect($changes)->toHaveCount(8);
 
         foreach ($changes as $key => $value) {
             $old = $settings[$key];
             $new = null;
-            $this->assertSame(compact('old', 'new'), $value);
+            expect($value)->toBe(compact('old', 'new'));
         }
 
         $details = app()->make(DetailsIndex::class)(self::INDEX);
-        $this->assertSame($defaults, $details);
+        expect($details)->toBe($defaults);
     });
 });
 
@@ -53,15 +53,15 @@ test('with pretend', function () {
         app()->make(SynchronizesIndex::class)(self::INDEX, $settings);
         $details = app()->make(DetailsIndex::class)(self::INDEX);
         $this->assertNotSame($defaults, $details);
-        $this->assertSame(array_replace($defaults, $settings), $details);
+        expect($details)->toBe(array_replace($defaults, $settings));
 
         $changes = app()->make(ResetsIndex::class)(self::INDEX, true);
-        $this->assertCount(8, $changes);
+        expect($changes)->toHaveCount(8);
 
         foreach ($changes as $key => $value) {
             $old = $settings[$key];
             $new = null;
-            $this->assertSame(compact('old', 'new'), $value);
+            expect($value)->toBe(compact('old', 'new'));
         }
 
         $details = app()->make(DetailsIndex::class)(self::INDEX);

--- a/tests/Actions/ResetsIndexTest.php
+++ b/tests/Actions/ResetsIndexTest.php
@@ -9,7 +9,6 @@ use Dwarf\MeiliTools\Helpers;
 use Dwarf\MeiliTools\Tests\TestCase;
 use Dwarf\MeiliTools\Tests\Tools;
 
-uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal

--- a/tests/Actions/ResetsModelTest.php
+++ b/tests/Actions/ResetsModelTest.php
@@ -7,8 +7,6 @@ use Dwarf\MeiliTools\Contracts\Actions\ResetsModel;
 use Dwarf\MeiliTools\Contracts\Actions\SynchronizesModel;
 use Dwarf\MeiliTools\Helpers;
 use Dwarf\MeiliTools\Tests\Models\MeiliMovie;
-use Dwarf\MeiliTools\Tests\TestCase;
-
 
 /**
  * @internal

--- a/tests/Actions/ResetsModelTest.php
+++ b/tests/Actions/ResetsModelTest.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-namespace Dwarf\MeiliTools\Tests\Actions;
-
 use Dwarf\MeiliTools\Contracts\Actions\DetailsModel;
 use Dwarf\MeiliTools\Contracts\Actions\ResetsModel;
 use Dwarf\MeiliTools\Contracts\Actions\SynchronizesModel;
@@ -11,68 +9,66 @@ use Dwarf\MeiliTools\Helpers;
 use Dwarf\MeiliTools\Tests\Models\MeiliMovie;
 use Dwarf\MeiliTools\Tests\TestCase;
 
+uses(Dwarf\MeiliTools\Tests\TestCase::class);
+
 /**
  * @internal
  */
-class ResetsModelTest extends TestCase
-{
-    /**
-     * Test ResetsModel::__invoke() method with advanced settings.
-     */
-    public function test_with_advanced_settings(): void
-    {
-        try {
-            $defaults = Helpers::defaultSettings(Helpers::engineVersion());
-            $settings = app(MeiliMovie::class)->meiliSettings();
 
-            $this->app->make(SynchronizesModel::class)(MeiliMovie::class);
-            $details = $this->app->make(DetailsModel::class)(MeiliMovie::class);
-            $this->assertNotSame($defaults, $details);
-            $this->assertSame(array_replace($defaults, $settings), $details);
+/**
+ * Test ResetsModel::__invoke() method with advanced settings.
+ */
+test('with advanced settings', function () {
+    try {
+        $defaults = Helpers::defaultSettings(Helpers::engineVersion());
+        $settings = app(MeiliMovie::class)->meiliSettings();
 
-            $changes = $this->app->make(ResetsModel::class)(MeiliMovie::class);
-            $this->assertCount(8, $changes);
+        app()->make(SynchronizesModel::class)(MeiliMovie::class);
+        $details = app()->make(DetailsModel::class)(MeiliMovie::class);
+        $this->assertNotSame($defaults, $details);
+        $this->assertSame(array_replace($defaults, $settings), $details);
 
-            foreach ($changes as $key => $value) {
-                $old = $settings[$key];
-                $new = null;
-                $this->assertSame(compact('old', 'new'), $value);
-            }
+        $changes = app()->make(ResetsModel::class)(MeiliMovie::class);
+        $this->assertCount(8, $changes);
 
-            $details = $this->app->make(DetailsModel::class)(MeiliMovie::class);
-            $this->assertSame($defaults, $details);
-        } finally {
-            $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
+        foreach ($changes as $key => $value) {
+            $old = $settings[$key];
+            $new = null;
+            $this->assertSame(compact('old', 'new'), $value);
         }
+
+        $details = app()->make(DetailsModel::class)(MeiliMovie::class);
+        $this->assertSame($defaults, $details);
+    } finally {
+        $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
     }
+});
 
-    /**
-     * Test ResetsModel::__invoke() method with pretend option.
-     */
-    public function test_with_pretend(): void
-    {
-        try {
-            $defaults = Helpers::defaultSettings(Helpers::engineVersion());
-            $settings = app(MeiliMovie::class)->meiliSettings();
+/**
+ * Test ResetsModel::__invoke() method with pretend option.
+ */
+test('with pretend', function () {
+    try {
+        $defaults = Helpers::defaultSettings(Helpers::engineVersion());
+        $settings = app(MeiliMovie::class)->meiliSettings();
 
-            $this->app->make(SynchronizesModel::class)(MeiliMovie::class);
-            $details = $this->app->make(DetailsModel::class)(MeiliMovie::class);
-            $this->assertNotSame($defaults, $details);
-            $this->assertSame(array_replace($defaults, $settings), $details);
+        app()->make(SynchronizesModel::class)(MeiliMovie::class);
+        $details = app()->make(DetailsModel::class)(MeiliMovie::class);
+        $this->assertNotSame($defaults, $details);
+        $this->assertSame(array_replace($defaults, $settings), $details);
 
-            $changes = $this->app->make(ResetsModel::class)(MeiliMovie::class, true);
-            $this->assertCount(8, $changes);
+        $changes = app()->make(ResetsModel::class)(MeiliMovie::class, true);
+        $this->assertCount(8, $changes);
 
-            foreach ($changes as $key => $value) {
-                $old = $settings[$key];
-                $new = null;
-                $this->assertSame(compact('old', 'new'), $value);
-            }
-
-            $details = $this->app->make(DetailsModel::class)(MeiliMovie::class);
-            $this->assertNotSame($defaults, $details);
-        } finally {
-            $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
+        foreach ($changes as $key => $value) {
+            $old = $settings[$key];
+            $new = null;
+            $this->assertSame(compact('old', 'new'), $value);
         }
+
+        $details = app()->make(DetailsModel::class)(MeiliMovie::class);
+        $this->assertNotSame($defaults, $details);
+    } finally {
+        $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
     }
-}
+});

--- a/tests/Actions/ResetsModelTest.php
+++ b/tests/Actions/ResetsModelTest.php
@@ -9,7 +9,6 @@ use Dwarf\MeiliTools\Helpers;
 use Dwarf\MeiliTools\Tests\Models\MeiliMovie;
 use Dwarf\MeiliTools\Tests\TestCase;
 
-uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal

--- a/tests/Actions/ResetsModelTest.php
+++ b/tests/Actions/ResetsModelTest.php
@@ -26,19 +26,19 @@ test('with advanced settings', function () {
         app()->make(SynchronizesModel::class)(MeiliMovie::class);
         $details = app()->make(DetailsModel::class)(MeiliMovie::class);
         $this->assertNotSame($defaults, $details);
-        $this->assertSame(array_replace($defaults, $settings), $details);
+        expect($details)->toBe(array_replace($defaults, $settings));
 
         $changes = app()->make(ResetsModel::class)(MeiliMovie::class);
-        $this->assertCount(8, $changes);
+        expect($changes)->toHaveCount(8);
 
         foreach ($changes as $key => $value) {
             $old = $settings[$key];
             $new = null;
-            $this->assertSame(compact('old', 'new'), $value);
+            expect($value)->toBe(compact('old', 'new'));
         }
 
         $details = app()->make(DetailsModel::class)(MeiliMovie::class);
-        $this->assertSame($defaults, $details);
+        expect($details)->toBe($defaults);
     } finally {
         $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
     }
@@ -55,15 +55,15 @@ test('with pretend', function () {
         app()->make(SynchronizesModel::class)(MeiliMovie::class);
         $details = app()->make(DetailsModel::class)(MeiliMovie::class);
         $this->assertNotSame($defaults, $details);
-        $this->assertSame(array_replace($defaults, $settings), $details);
+        expect($details)->toBe(array_replace($defaults, $settings));
 
         $changes = app()->make(ResetsModel::class)(MeiliMovie::class, true);
-        $this->assertCount(8, $changes);
+        expect($changes)->toHaveCount(8);
 
         foreach ($changes as $key => $value) {
             $old = $settings[$key];
             $new = null;
-            $this->assertSame(compact('old', 'new'), $value);
+            expect($value)->toBe(compact('old', 'new'));
         }
 
         $details = app()->make(DetailsModel::class)(MeiliMovie::class);

--- a/tests/Actions/SynchronizesIndexTest.php
+++ b/tests/Actions/SynchronizesIndexTest.php
@@ -8,7 +8,6 @@ use Dwarf\MeiliTools\Tests\TestCase;
 use Dwarf\MeiliTools\Tests\Tools;
 use Illuminate\Support\Arr;
 
-uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal

--- a/tests/Actions/SynchronizesIndexTest.php
+++ b/tests/Actions/SynchronizesIndexTest.php
@@ -22,18 +22,18 @@ test('with changing movie settings', function () {
         $action = app()->make(SynchronizesIndex::class);
 
         $changes = ($action)(self::INDEX, []);
-        $this->assertSame([], $changes);
+        expect($changes)->toBe([]);
 
         $defaults = Helpers::defaultSettings(Helpers::engineVersion());
         $settings = Tools::movieSettings();
 
         $changes = ($action)(self::INDEX, $settings);
-        $this->assertCount(8, $changes);
+        expect($changes)->toHaveCount(8);
 
         foreach ($changes as $key => $value) {
             $old = $defaults[$key];
             $new = $settings[$key];
-            $this->assertSame(compact('old', 'new'), $value);
+            expect($value)->toBe(compact('old', 'new'));
         }
 
         $update1 = [
@@ -42,12 +42,12 @@ test('with changing movie settings', function () {
             'synonyms'           => null,
         ];
         $changes = ($action)(self::INDEX, $update1);
-        $this->assertCount(3, $changes);
+        expect($changes)->toHaveCount(3);
 
         foreach ($changes as $key => $value) {
             $old = $settings[$key];
             $new = $update1[$key];
-            $this->assertSame(compact('old', 'new'), $value);
+            expect($value)->toBe(compact('old', 'new'));
         }
 
         $update2 = [
@@ -56,12 +56,12 @@ test('with changing movie settings', function () {
             'stopWords'           => null,
         ];
         $changes = ($action)(self::INDEX, $update2);
-        $this->assertCount(1, $changes);
+        expect($changes)->toHaveCount(1);
 
         foreach ($changes as $key => $value) {
             $old = $settings[$key];
             $new = $update2[$key];
-            $this->assertSame(compact('old', 'new'), $value);
+            expect($value)->toBe(compact('old', 'new'));
         }
 
         $update3 = [
@@ -71,12 +71,12 @@ test('with changing movie settings', function () {
             'stopWords'            => $settings['stopWords'],
         ];
         $changes = ($action)(self::INDEX, $update3);
-        $this->assertCount(3, $changes);
+        expect($changes)->toHaveCount(3);
 
         foreach ($changes as $key => $value) {
             $old = $key === 'stopWords' ? $defaults[$key] : $settings[$key];
             $new = $update3[$key];
-            $this->assertSame(compact('old', 'new'), $value);
+            expect($value)->toBe(compact('old', 'new'));
         }
 
         $update4 = [
@@ -90,16 +90,16 @@ test('with changing movie settings', function () {
             'synonyms'             => null,
         ];
         $changes = ($action)(self::INDEX, $update4);
-        $this->assertCount(3, $changes);
+        expect($changes)->toHaveCount(3);
 
         foreach ($changes as $key => $value) {
             $old = $settings[$key];
             $new = $update4[$key];
-            $this->assertSame(compact('old', 'new'), $value);
+            expect($value)->toBe(compact('old', 'new'));
         }
 
         $changes = ($action)(self::INDEX, $update4);
-        $this->assertEmpty($changes);
+        expect($changes)->toBeEmpty();
     });
 });
 
@@ -125,14 +125,14 @@ test('with typo tolerance settings', function () {
         $updates = ['typoTolerance' => $update];
         $expected = ['typoTolerance' => ['old' => $current, 'new' => $update]];
         $changes = ($action)(self::INDEX, $updates);
-        $this->assertCount(1, $changes);
-        $this->assertCount(1, $changes['typoTolerance']['old']);
-        $this->assertCount(1, $changes['typoTolerance']['new']);
-        $this->assertSame($expected, $changes);
+        expect($changes)->toHaveCount(1);
+        expect($changes['typoTolerance']['old'])->toHaveCount(1);
+        expect($changes['typoTolerance']['new'])->toHaveCount(1);
+        expect($changes)->toBe($expected);
 
         // Attempting to do the same updates should result in zero changes.
         $changes = ($action)(self::INDEX, $updates);
-        $this->assertCount(0, $changes);
+        expect($changes)->toHaveCount(0);
 
         $default = array_replace($default, $update);
         $update = [
@@ -146,14 +146,14 @@ test('with typo tolerance settings', function () {
         $updates = ['typoTolerance' => $update];
         $expected = ['typoTolerance' => ['old' => $current, 'new' => $update]];
         $changes = ($action)(self::INDEX, $updates);
-        $this->assertCount(1, $changes);
-        $this->assertCount(2, $changes['typoTolerance']['old']);
-        $this->assertCount(2, $changes['typoTolerance']['new']);
-        $this->assertSame($expected, $changes);
+        expect($changes)->toHaveCount(1);
+        expect($changes['typoTolerance']['old'])->toHaveCount(2);
+        expect($changes['typoTolerance']['new'])->toHaveCount(2);
+        expect($changes)->toBe($expected);
 
         // Attempting to do the same updates should result in zero changes.
         $changes = ($action)(self::INDEX, $updates);
-        $this->assertCount(0, $changes);
+        expect($changes)->toHaveCount(0);
 
         $default = array_replace($default, $update, Arr::only($defaults['typoTolerance'], 'enabled'));
         $update = [
@@ -165,14 +165,14 @@ test('with typo tolerance settings', function () {
         sort($update['disableOnWords']); // List is sorted automatically before update.
         $expected = ['typoTolerance' => ['old' => $current, 'new' => $update]];
         $changes = ($action)(self::INDEX, $updates);
-        $this->assertCount(1, $changes);
-        $this->assertCount(2, $changes['typoTolerance']['old']);
-        $this->assertCount(2, $changes['typoTolerance']['new']);
-        $this->assertSame($expected, $changes);
+        expect($changes)->toHaveCount(1);
+        expect($changes['typoTolerance']['old'])->toHaveCount(2);
+        expect($changes['typoTolerance']['new'])->toHaveCount(2);
+        expect($changes)->toBe($expected);
 
         // Attempting to do the same updates should result in zero changes.
         $changes = ($action)(self::INDEX, $updates);
-        $this->assertCount(0, $changes);
+        expect($changes)->toHaveCount(0);
 
         $default = array_replace($default, $update, Arr::only($defaults['typoTolerance'], 'minWordSizeForTypos'));
         $update = [
@@ -184,14 +184,14 @@ test('with typo tolerance settings', function () {
         sort($update['disableOnAttributes']); // List is sorted automatically before update.
         $expected = ['typoTolerance' => ['old' => $current, 'new' => $update]];
         $changes = ($action)(self::INDEX, $updates);
-        $this->assertCount(1, $changes);
-        $this->assertCount(2, $changes['typoTolerance']['old']);
-        $this->assertCount(2, $changes['typoTolerance']['new']);
-        $this->assertSame($expected, $changes);
+        expect($changes)->toHaveCount(1);
+        expect($changes['typoTolerance']['old'])->toHaveCount(2);
+        expect($changes['typoTolerance']['new'])->toHaveCount(2);
+        expect($changes)->toBe($expected);
 
         // Attempting to do the same updates should result in zero changes.
         $changes = ($action)(self::INDEX, $updates);
-        $this->assertCount(0, $changes);
+        expect($changes)->toHaveCount(0);
 
         $default = Arr::only($update, 'disableOnAttributes');
         $update = [
@@ -203,14 +203,14 @@ test('with typo tolerance settings', function () {
         $updates = ['typoTolerance' => $update];
         $expected = ['typoTolerance' => ['old' => $current, 'new' => Arr::only($update, 'disableOnAttributes')]];
         $changes = ($action)(self::INDEX, $updates);
-        $this->assertCount(1, $changes);
-        $this->assertCount(1, $changes['typoTolerance']['old']);
-        $this->assertCount(1, $changes['typoTolerance']['new']);
-        $this->assertSame($expected, $changes);
+        expect($changes)->toHaveCount(1);
+        expect($changes['typoTolerance']['old'])->toHaveCount(1);
+        expect($changes['typoTolerance']['new'])->toHaveCount(1);
+        expect($changes)->toBe($expected);
 
         // Attempting to do the same updates should result in zero changes.
         $changes = ($action)(self::INDEX, $updates);
-        $this->assertCount(0, $changes);
+        expect($changes)->toHaveCount(0);
     });
 });
 
@@ -222,18 +222,18 @@ test('with pretend', function () {
         $action = app()->make(SynchronizesIndex::class);
 
         $changes = ($action)(self::INDEX, []);
-        $this->assertSame([], $changes);
+        expect($changes)->toBe([]);
 
         $defaults = Helpers::defaultSettings(Helpers::engineVersion());
         $settings = Tools::movieSettings();
 
         $changes = ($action)(self::INDEX, $settings, true);
-        $this->assertCount(8, $changes);
+        expect($changes)->toHaveCount(8);
 
         foreach ($changes as $key => $value) {
             $old = $defaults[$key];
             $new = $settings[$key];
-            $this->assertSame(compact('old', 'new'), $value);
+            expect($value)->toBe(compact('old', 'new'));
         }
 
         $update = [
@@ -247,6 +247,6 @@ test('with pretend', function () {
             'synonyms'             => null,
         ];
         $changes = ($action)(self::INDEX, $update);
-        $this->assertEmpty($changes);
+        expect($changes)->toBeEmpty();
     });
 });

--- a/tests/Actions/SynchronizesIndexTest.php
+++ b/tests/Actions/SynchronizesIndexTest.php
@@ -2,263 +2,251 @@
 
 declare(strict_types=1);
 
-namespace Dwarf\MeiliTools\Tests\Actions;
-
 use Dwarf\MeiliTools\Contracts\Actions\SynchronizesIndex;
 use Dwarf\MeiliTools\Helpers;
 use Dwarf\MeiliTools\Tests\TestCase;
 use Dwarf\MeiliTools\Tests\Tools;
 use Illuminate\Support\Arr;
 
+uses(Dwarf\MeiliTools\Tests\TestCase::class);
+
 /**
  * @internal
  */
-class SynchronizesIndexTest extends TestCase
-{
-    /**
-     * Test index.
-     *
-     * @var string
-     */
-    private const INDEX = 'testing-synchronizes-index';
 
-    /**
-     * Test SynchronizesIndex::__invoke() method with movie settings.
-     */
-    public function test_with_changing_movie_settings(): void
-    {
-        $this->withIndex(self::INDEX, function () {
-            $action = $this->app->make(SynchronizesIndex::class);
+/**
+ * Test SynchronizesIndex::__invoke() method with movie settings.
+ */
+test('with changing movie settings', function () {
+    $this->withIndex(self::INDEX, function () {
+        $action = app()->make(SynchronizesIndex::class);
 
-            $changes = ($action)(self::INDEX, []);
-            $this->assertSame([], $changes);
+        $changes = ($action)(self::INDEX, []);
+        $this->assertSame([], $changes);
 
-            $defaults = Helpers::defaultSettings(Helpers::engineVersion());
-            $settings = Tools::movieSettings();
+        $defaults = Helpers::defaultSettings(Helpers::engineVersion());
+        $settings = Tools::movieSettings();
 
-            $changes = ($action)(self::INDEX, $settings);
-            $this->assertCount(8, $changes);
+        $changes = ($action)(self::INDEX, $settings);
+        $this->assertCount(8, $changes);
 
-            foreach ($changes as $key => $value) {
-                $old = $defaults[$key];
-                $new = $settings[$key];
-                $this->assertSame(compact('old', 'new'), $value);
-            }
-
-            $update1 = [
-                'stopWords'          => null,
-                'sortableAttributes' => null,
-                'synonyms'           => null,
-            ];
-            $changes = ($action)(self::INDEX, $update1);
-            $this->assertCount(3, $changes);
-
-            foreach ($changes as $key => $value) {
-                $old = $settings[$key];
-                $new = $update1[$key];
-                $this->assertSame(compact('old', 'new'), $value);
-            }
-
-            $update2 = [
-                'distinctAttribute'   => 'movie_id',
-                'displayedAttributes' => null,
-                'stopWords'           => null,
-            ];
-            $changes = ($action)(self::INDEX, $update2);
-            $this->assertCount(1, $changes);
-
-            foreach ($changes as $key => $value) {
-                $old = $settings[$key];
-                $new = $update2[$key];
-                $this->assertSame(compact('old', 'new'), $value);
-            }
-
-            $update3 = [
-                'distinctAttribute'    => null,
-                'searchableAttributes' => null,
-                'displayedAttributes'  => null,
-                'stopWords'            => $settings['stopWords'],
-            ];
-            $changes = ($action)(self::INDEX, $update3);
-            $this->assertCount(3, $changes);
-
-            foreach ($changes as $key => $value) {
-                $old = $key === 'stopWords' ? $defaults[$key] : $settings[$key];
-                $new = $update3[$key];
-                $this->assertSame(compact('old', 'new'), $value);
-            }
-
-            $update4 = [
-                'displayedAttributes'  => null,
-                'distinctAttribute'    => null,
-                'filterableAttributes' => null,
-                'rankingRules'         => null,
-                'searchableAttributes' => null,
-                'sortableAttributes'   => null,
-                'stopWords'            => null,
-                'synonyms'             => null,
-            ];
-            $changes = ($action)(self::INDEX, $update4);
-            $this->assertCount(3, $changes);
-
-            foreach ($changes as $key => $value) {
-                $old = $settings[$key];
-                $new = $update4[$key];
-                $this->assertSame(compact('old', 'new'), $value);
-            }
-
-            $changes = ($action)(self::INDEX, $update4);
-            $this->assertEmpty($changes);
-        });
-    }
-
-    /**
-     * Test SynchronizesIndex::__invoke() method with typo tolerance settings.
-     */
-    public function test_with_typo_tolerance_settings(): void
-    {
-        // Check if test should be run on this engine version.
-        $version = Helpers::engineVersion() ?: '0.0.0';
-        if (version_compare($version, '0.27.0', '<')) {
-            $this->markTestSkipped('Typo tolerance is only available from 0.27.0 and up.');
+        foreach ($changes as $key => $value) {
+            $old = $defaults[$key];
+            $new = $settings[$key];
+            $this->assertSame(compact('old', 'new'), $value);
         }
 
-        $this->withIndex(self::INDEX, function () use ($version) {
-            $action = $this->app->make(SynchronizesIndex::class);
+        $update1 = [
+            'stopWords'          => null,
+            'sortableAttributes' => null,
+            'synonyms'           => null,
+        ];
+        $changes = ($action)(self::INDEX, $update1);
+        $this->assertCount(3, $changes);
 
-            // Grab default settings.
-            $defaults = Helpers::defaultSettings($version);
-            $default = $defaults['typoTolerance'];
+        foreach ($changes as $key => $value) {
+            $old = $settings[$key];
+            $new = $update1[$key];
+            $this->assertSame(compact('old', 'new'), $value);
+        }
 
-            $update = ['enabled' => false];
-            $current = Arr::only($default, array_keys($update));
-            $updates = ['typoTolerance' => $update];
-            $expected = ['typoTolerance' => ['old' => $current, 'new' => $update]];
-            $changes = ($action)(self::INDEX, $updates);
-            $this->assertCount(1, $changes);
-            $this->assertCount(1, $changes['typoTolerance']['old']);
-            $this->assertCount(1, $changes['typoTolerance']['new']);
-            $this->assertSame($expected, $changes);
+        $update2 = [
+            'distinctAttribute'   => 'movie_id',
+            'displayedAttributes' => null,
+            'stopWords'           => null,
+        ];
+        $changes = ($action)(self::INDEX, $update2);
+        $this->assertCount(1, $changes);
 
-            // Attempting to do the same updates should result in zero changes.
-            $changes = ($action)(self::INDEX, $updates);
-            $this->assertCount(0, $changes);
+        foreach ($changes as $key => $value) {
+            $old = $settings[$key];
+            $new = $update2[$key];
+            $this->assertSame(compact('old', 'new'), $value);
+        }
 
-            $default = array_replace($default, $update);
-            $update = [
-                'enabled'             => null,
-                'minWordSizeForTypos' => [
-                    'oneTypo'  => 2,
-                    'twoTypos' => 6,
-                ],
-            ];
-            $current = Arr::only($default, array_keys($update));
-            $updates = ['typoTolerance' => $update];
-            $expected = ['typoTolerance' => ['old' => $current, 'new' => $update]];
-            $changes = ($action)(self::INDEX, $updates);
-            $this->assertCount(1, $changes);
-            $this->assertCount(2, $changes['typoTolerance']['old']);
-            $this->assertCount(2, $changes['typoTolerance']['new']);
-            $this->assertSame($expected, $changes);
+        $update3 = [
+            'distinctAttribute'    => null,
+            'searchableAttributes' => null,
+            'displayedAttributes'  => null,
+            'stopWords'            => $settings['stopWords'],
+        ];
+        $changes = ($action)(self::INDEX, $update3);
+        $this->assertCount(3, $changes);
 
-            // Attempting to do the same updates should result in zero changes.
-            $changes = ($action)(self::INDEX, $updates);
-            $this->assertCount(0, $changes);
+        foreach ($changes as $key => $value) {
+            $old = $key === 'stopWords' ? $defaults[$key] : $settings[$key];
+            $new = $update3[$key];
+            $this->assertSame(compact('old', 'new'), $value);
+        }
 
-            $default = array_replace($default, $update, Arr::only($defaults['typoTolerance'], 'enabled'));
-            $update = [
-                'minWordSizeForTypos' => null,
-                'disableOnWords'      => ['title', 'rank'],
-            ];
-            $current = Arr::only($default, array_keys($update));
-            $updates = ['typoTolerance' => $update];
-            sort($update['disableOnWords']); // List is sorted automatically before update.
-            $expected = ['typoTolerance' => ['old' => $current, 'new' => $update]];
-            $changes = ($action)(self::INDEX, $updates);
-            $this->assertCount(1, $changes);
-            $this->assertCount(2, $changes['typoTolerance']['old']);
-            $this->assertCount(2, $changes['typoTolerance']['new']);
-            $this->assertSame($expected, $changes);
+        $update4 = [
+            'displayedAttributes'  => null,
+            'distinctAttribute'    => null,
+            'filterableAttributes' => null,
+            'rankingRules'         => null,
+            'searchableAttributes' => null,
+            'sortableAttributes'   => null,
+            'stopWords'            => null,
+            'synonyms'             => null,
+        ];
+        $changes = ($action)(self::INDEX, $update4);
+        $this->assertCount(3, $changes);
 
-            // Attempting to do the same updates should result in zero changes.
-            $changes = ($action)(self::INDEX, $updates);
-            $this->assertCount(0, $changes);
+        foreach ($changes as $key => $value) {
+            $old = $settings[$key];
+            $new = $update4[$key];
+            $this->assertSame(compact('old', 'new'), $value);
+        }
 
-            $default = array_replace($default, $update, Arr::only($defaults['typoTolerance'], 'minWordSizeForTypos'));
-            $update = [
-                'disableOnWords'      => null,
-                'disableOnAttributes' => ['title', 'rank'],
-            ];
-            $current = Arr::only($default, array_keys($update));
-            $updates = ['typoTolerance' => $update];
-            sort($update['disableOnAttributes']); // List is sorted automatically before update.
-            $expected = ['typoTolerance' => ['old' => $current, 'new' => $update]];
-            $changes = ($action)(self::INDEX, $updates);
-            $this->assertCount(1, $changes);
-            $this->assertCount(2, $changes['typoTolerance']['old']);
-            $this->assertCount(2, $changes['typoTolerance']['new']);
-            $this->assertSame($expected, $changes);
+        $changes = ($action)(self::INDEX, $update4);
+        $this->assertEmpty($changes);
+    });
+});
 
-            // Attempting to do the same updates should result in zero changes.
-            $changes = ($action)(self::INDEX, $updates);
-            $this->assertCount(0, $changes);
-
-            $default = Arr::only($update, 'disableOnAttributes');
-            $update = [
-                'minWordSizeForTypos' => null,
-                'disableOnWords'      => null,
-                'disableOnAttributes' => null,
-            ];
-            $current = Arr::only($default, array_keys($update));
-            $updates = ['typoTolerance' => $update];
-            $expected = ['typoTolerance' => ['old' => $current, 'new' => Arr::only($update, 'disableOnAttributes')]];
-            $changes = ($action)(self::INDEX, $updates);
-            $this->assertCount(1, $changes);
-            $this->assertCount(1, $changes['typoTolerance']['old']);
-            $this->assertCount(1, $changes['typoTolerance']['new']);
-            $this->assertSame($expected, $changes);
-
-            // Attempting to do the same updates should result in zero changes.
-            $changes = ($action)(self::INDEX, $updates);
-            $this->assertCount(0, $changes);
-        });
+/**
+ * Test SynchronizesIndex::__invoke() method with typo tolerance settings.
+ */
+test('with typo tolerance settings', function () {
+    // Check if test should be run on this engine version.
+    $version = Helpers::engineVersion() ?: '0.0.0';
+    if (version_compare($version, '0.27.0', '<')) {
+        $this->markTestSkipped('Typo tolerance is only available from 0.27.0 and up.');
     }
 
-    /**
-     * Test SynchronizesIndex::__invoke() method with pretend.
-     */
-    public function test_with_pretend(): void
-    {
-        $this->withIndex(self::INDEX, function () {
-            $action = $this->app->make(SynchronizesIndex::class);
+    $this->withIndex(self::INDEX, function () use ($version) {
+        $action = app()->make(SynchronizesIndex::class);
 
-            $changes = ($action)(self::INDEX, []);
-            $this->assertSame([], $changes);
+        // Grab default settings.
+        $defaults = Helpers::defaultSettings($version);
+        $default = $defaults['typoTolerance'];
 
-            $defaults = Helpers::defaultSettings(Helpers::engineVersion());
-            $settings = Tools::movieSettings();
+        $update = ['enabled' => false];
+        $current = Arr::only($default, array_keys($update));
+        $updates = ['typoTolerance' => $update];
+        $expected = ['typoTolerance' => ['old' => $current, 'new' => $update]];
+        $changes = ($action)(self::INDEX, $updates);
+        $this->assertCount(1, $changes);
+        $this->assertCount(1, $changes['typoTolerance']['old']);
+        $this->assertCount(1, $changes['typoTolerance']['new']);
+        $this->assertSame($expected, $changes);
 
-            $changes = ($action)(self::INDEX, $settings, true);
-            $this->assertCount(8, $changes);
+        // Attempting to do the same updates should result in zero changes.
+        $changes = ($action)(self::INDEX, $updates);
+        $this->assertCount(0, $changes);
 
-            foreach ($changes as $key => $value) {
-                $old = $defaults[$key];
-                $new = $settings[$key];
-                $this->assertSame(compact('old', 'new'), $value);
-            }
+        $default = array_replace($default, $update);
+        $update = [
+            'enabled'             => null,
+            'minWordSizeForTypos' => [
+                'oneTypo'  => 2,
+                'twoTypos' => 6,
+            ],
+        ];
+        $current = Arr::only($default, array_keys($update));
+        $updates = ['typoTolerance' => $update];
+        $expected = ['typoTolerance' => ['old' => $current, 'new' => $update]];
+        $changes = ($action)(self::INDEX, $updates);
+        $this->assertCount(1, $changes);
+        $this->assertCount(2, $changes['typoTolerance']['old']);
+        $this->assertCount(2, $changes['typoTolerance']['new']);
+        $this->assertSame($expected, $changes);
 
-            $update = [
-                'displayedAttributes'  => null,
-                'distinctAttribute'    => null,
-                'filterableAttributes' => null,
-                'rankingRules'         => null,
-                'searchableAttributes' => null,
-                'sortableAttributes'   => null,
-                'stopWords'            => null,
-                'synonyms'             => null,
-            ];
-            $changes = ($action)(self::INDEX, $update);
-            $this->assertEmpty($changes);
-        });
-    }
-}
+        // Attempting to do the same updates should result in zero changes.
+        $changes = ($action)(self::INDEX, $updates);
+        $this->assertCount(0, $changes);
+
+        $default = array_replace($default, $update, Arr::only($defaults['typoTolerance'], 'enabled'));
+        $update = [
+            'minWordSizeForTypos' => null,
+            'disableOnWords'      => ['title', 'rank'],
+        ];
+        $current = Arr::only($default, array_keys($update));
+        $updates = ['typoTolerance' => $update];
+        sort($update['disableOnWords']); // List is sorted automatically before update.
+        $expected = ['typoTolerance' => ['old' => $current, 'new' => $update]];
+        $changes = ($action)(self::INDEX, $updates);
+        $this->assertCount(1, $changes);
+        $this->assertCount(2, $changes['typoTolerance']['old']);
+        $this->assertCount(2, $changes['typoTolerance']['new']);
+        $this->assertSame($expected, $changes);
+
+        // Attempting to do the same updates should result in zero changes.
+        $changes = ($action)(self::INDEX, $updates);
+        $this->assertCount(0, $changes);
+
+        $default = array_replace($default, $update, Arr::only($defaults['typoTolerance'], 'minWordSizeForTypos'));
+        $update = [
+            'disableOnWords'      => null,
+            'disableOnAttributes' => ['title', 'rank'],
+        ];
+        $current = Arr::only($default, array_keys($update));
+        $updates = ['typoTolerance' => $update];
+        sort($update['disableOnAttributes']); // List is sorted automatically before update.
+        $expected = ['typoTolerance' => ['old' => $current, 'new' => $update]];
+        $changes = ($action)(self::INDEX, $updates);
+        $this->assertCount(1, $changes);
+        $this->assertCount(2, $changes['typoTolerance']['old']);
+        $this->assertCount(2, $changes['typoTolerance']['new']);
+        $this->assertSame($expected, $changes);
+
+        // Attempting to do the same updates should result in zero changes.
+        $changes = ($action)(self::INDEX, $updates);
+        $this->assertCount(0, $changes);
+
+        $default = Arr::only($update, 'disableOnAttributes');
+        $update = [
+            'minWordSizeForTypos' => null,
+            'disableOnWords'      => null,
+            'disableOnAttributes' => null,
+        ];
+        $current = Arr::only($default, array_keys($update));
+        $updates = ['typoTolerance' => $update];
+        $expected = ['typoTolerance' => ['old' => $current, 'new' => Arr::only($update, 'disableOnAttributes')]];
+        $changes = ($action)(self::INDEX, $updates);
+        $this->assertCount(1, $changes);
+        $this->assertCount(1, $changes['typoTolerance']['old']);
+        $this->assertCount(1, $changes['typoTolerance']['new']);
+        $this->assertSame($expected, $changes);
+
+        // Attempting to do the same updates should result in zero changes.
+        $changes = ($action)(self::INDEX, $updates);
+        $this->assertCount(0, $changes);
+    });
+});
+
+/**
+ * Test SynchronizesIndex::__invoke() method with pretend.
+ */
+test('with pretend', function () {
+    $this->withIndex(self::INDEX, function () {
+        $action = app()->make(SynchronizesIndex::class);
+
+        $changes = ($action)(self::INDEX, []);
+        $this->assertSame([], $changes);
+
+        $defaults = Helpers::defaultSettings(Helpers::engineVersion());
+        $settings = Tools::movieSettings();
+
+        $changes = ($action)(self::INDEX, $settings, true);
+        $this->assertCount(8, $changes);
+
+        foreach ($changes as $key => $value) {
+            $old = $defaults[$key];
+            $new = $settings[$key];
+            $this->assertSame(compact('old', 'new'), $value);
+        }
+
+        $update = [
+            'displayedAttributes'  => null,
+            'distinctAttribute'    => null,
+            'filterableAttributes' => null,
+            'rankingRules'         => null,
+            'searchableAttributes' => null,
+            'sortableAttributes'   => null,
+            'stopWords'            => null,
+            'synonyms'             => null,
+        ];
+        $changes = ($action)(self::INDEX, $update);
+        $this->assertEmpty($changes);
+    });
+});

--- a/tests/Actions/SynchronizesIndexTest.php
+++ b/tests/Actions/SynchronizesIndexTest.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 use Dwarf\MeiliTools\Contracts\Actions\SynchronizesIndex;
 use Dwarf\MeiliTools\Helpers;
-use Dwarf\MeiliTools\Tests\TestCase;
 use Dwarf\MeiliTools\Tests\Tools;
 use Illuminate\Support\Arr;
-
 
 /**
  * @internal

--- a/tests/Actions/SynchronizesModelTest.php
+++ b/tests/Actions/SynchronizesModelTest.php
@@ -8,10 +8,8 @@ use Dwarf\MeiliTools\Helpers;
 use Dwarf\MeiliTools\Tests\Models\BrokenMovie;
 use Dwarf\MeiliTools\Tests\Models\MeiliMovie;
 use Dwarf\MeiliTools\Tests\Models\Movie;
-use Dwarf\MeiliTools\Tests\TestCase;
 use Illuminate\Support\Arr;
 use Illuminate\Validation\ValidationException;
-
 
 /**
  * @internal

--- a/tests/Actions/SynchronizesModelTest.php
+++ b/tests/Actions/SynchronizesModelTest.php
@@ -66,13 +66,13 @@ test('with advanced settings', function () {
         ;
 
         $details = app()->make(DetailsModel::class)(MeiliMovie::class);
-        $this->assertSame($defaults, $details);
+        expect($details)->toBe($defaults);
 
         $changes = app()->make(SynchronizesModel::class)(MeiliMovie::class);
-        $this->assertSame($expected, $changes);
+        expect($changes)->toBe($expected);
 
         $details = app()->make(DetailsModel::class)(MeiliMovie::class);
-        $this->assertSame($settings, Arr::except($details, ['faceting', 'pagination', 'typoTolerance']));
+        expect(Arr::except($details, ['faceting', 'pagination', 'typoTolerance']))->toBe($settings);
     } finally {
         $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
     }
@@ -97,13 +97,13 @@ test('with pretend', function () {
         ;
 
         $details = app()->make(DetailsModel::class)(MeiliMovie::class);
-        $this->assertSame($defaults, $details);
+        expect($details)->toBe($defaults);
 
         $changes = app()->make(SynchronizesModel::class)(MeiliMovie::class, true);
-        $this->assertSame($expected, $changes);
+        expect($changes)->toBe($expected);
 
         $details = app()->make(DetailsModel::class)(MeiliMovie::class);
-        $this->assertSame($defaults, $details);
+        expect($details)->toBe($defaults);
     } finally {
         $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
     }
@@ -132,13 +132,13 @@ test('with soft deletes enabled', function () {
         ;
 
         $details = app()->make(DetailsModel::class)(MeiliMovie::class);
-        $this->assertSame($defaults, $details);
+        expect($details)->toBe($defaults);
 
         $changes = app()->make(SynchronizesModel::class)(MeiliMovie::class);
-        $this->assertSame($expected, $changes);
+        expect($changes)->toBe($expected);
 
         $details = app()->make(DetailsModel::class)(MeiliMovie::class);
-        $this->assertSame($settings, Arr::except($details, ['faceting', 'pagination', 'typoTolerance']));
+        expect(Arr::except($details, ['faceting', 'pagination', 'typoTolerance']))->toBe($settings);
     } finally {
         $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
     }

--- a/tests/Actions/SynchronizesModelTest.php
+++ b/tests/Actions/SynchronizesModelTest.php
@@ -12,7 +12,6 @@ use Dwarf\MeiliTools\Tests\TestCase;
 use Illuminate\Support\Arr;
 use Illuminate\Validation\ValidationException;
 
-uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal

--- a/tests/Actions/SynchronizesModelTest.php
+++ b/tests/Actions/SynchronizesModelTest.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use BadMethodCallException;
 use Dwarf\MeiliTools\Contracts\Actions\DetailsModel;
 use Dwarf\MeiliTools\Contracts\Actions\SynchronizesModel;
 use Dwarf\MeiliTools\Helpers;

--- a/tests/Actions/SynchronizesModelsTest.php
+++ b/tests/Actions/SynchronizesModelsTest.php
@@ -7,9 +7,7 @@ use Dwarf\MeiliTools\Contracts\Actions\SynchronizesModels;
 use Dwarf\MeiliTools\Helpers;
 use Dwarf\MeiliTools\Tests\Models\MeiliMovie;
 use Dwarf\MeiliTools\Tests\Models\Movie;
-use Dwarf\MeiliTools\Tests\TestCase;
 use Illuminate\Support\Arr;
-
 
 /**
  * @internal

--- a/tests/Actions/SynchronizesModelsTest.php
+++ b/tests/Actions/SynchronizesModelsTest.php
@@ -41,25 +41,25 @@ test('with advanced settings', function () {
         ];
 
         $details = app()->make(DetailsModel::class)(Movie::class);
-        $this->assertSame($defaults, $details);
+        expect($details)->toBe($defaults);
         $details = app()->make(DetailsModel::class)(MeiliMovie::class);
-        $this->assertSame($defaults, $details);
+        expect($details)->toBe($defaults);
 
         $action = app()->make(SynchronizesModels::class);
         $action(array_keys($classes), function ($class, $result) use ($classes) {
             if (\is_array($result)) {
-                $this->assertSame($classes[$class], $result);
+                expect($result)->toBe($classes[$class]);
             } else {
-                $this->assertTrue($classes[$class] instanceof $result);
-                $this->assertSame($classes[$class]->getMessage(), $result->getMessage());
+                expect($classes[$class] instanceof $result)->toBeTrue();
+                expect($result->getMessage())->toBe($classes[$class]->getMessage());
             }
         });
 
         $details = app()->make(DetailsModel::class)(Movie::class);
-        $this->assertSame($defaults, $details);
+        expect($details)->toBe($defaults);
 
         $details = app()->make(DetailsModel::class)(MeiliMovie::class);
-        $this->assertSame($settings, Arr::except($details, ['faceting', 'pagination', 'typoTolerance']));
+        expect(Arr::except($details, ['faceting', 'pagination', 'typoTolerance']))->toBe($settings);
     } finally {
         $this->deleteIndex(app(Movie::class)->searchableAs());
         $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
@@ -85,15 +85,15 @@ test('with pretend', function () {
         ;
 
         $details = app()->make(DetailsModel::class)(MeiliMovie::class);
-        $this->assertSame($defaults, $details);
+        expect($details)->toBe($defaults);
 
         $action = app()->make(SynchronizesModels::class);
         $action([MeiliMovie::class], function ($class, $result) use ($expected) {
-            $this->assertSame($expected, $result);
+            expect($result)->toBe($expected);
         }, true);
 
         $details = app()->make(DetailsModel::class)(MeiliMovie::class);
-        $this->assertSame($defaults, $details);
+        expect($details)->toBe($defaults);
     } finally {
         $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
     }

--- a/tests/Actions/SynchronizesModelsTest.php
+++ b/tests/Actions/SynchronizesModelsTest.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-namespace Dwarf\MeiliTools\Tests\Actions;
-
 use BadMethodCallException;
 use Dwarf\MeiliTools\Contracts\Actions\DetailsModel;
 use Dwarf\MeiliTools\Contracts\Actions\SynchronizesModels;
@@ -13,93 +11,91 @@ use Dwarf\MeiliTools\Tests\Models\Movie;
 use Dwarf\MeiliTools\Tests\TestCase;
 use Illuminate\Support\Arr;
 
+uses(Dwarf\MeiliTools\Tests\TestCase::class);
+
 /**
  * @internal
  */
-class SynchronizesModelsTest extends TestCase
-{
-    /**
-     * Test SynchronizesModels::__invoke() method with advanced settings.
-     */
-    public function test_with_advanced_settings(): void
-    {
-        try {
-            $defaults = Helpers::defaultSettings(Helpers::engineVersion());
-            $settings = app(MeiliMovie::class)->meiliSettings();
-            $expected = collect($settings)
-                ->mapWithKeys(function ($value, $key) use ($defaults) {
-                    $old = $defaults[$key];
-                    $new = $value;
 
-                    return [$key => $old === $new ? false : compact('old', 'new')];
-                })
-                ->filter()
-                ->all()
-            ;
-            $exception = new BadMethodCallException('Call to undefined method ' . Movie::class . '::meiliSettings()');
+/**
+ * Test SynchronizesModels::__invoke() method with advanced settings.
+ */
+test('with advanced settings', function () {
+    try {
+        $defaults = Helpers::defaultSettings(Helpers::engineVersion());
+        $settings = app(MeiliMovie::class)->meiliSettings();
+        $expected = collect($settings)
+            ->mapWithKeys(function ($value, $key) use ($defaults) {
+                $old = $defaults[$key];
+                $new = $value;
 
-            $classes = [
-                Movie::class      => $exception,
-                MeiliMovie::class => $expected,
-            ];
+                return [$key => $old === $new ? false : compact('old', 'new')];
+            })
+            ->filter()
+            ->all()
+        ;
+        $exception = new BadMethodCallException('Call to undefined method ' . Movie::class . '::meiliSettings()');
 
-            $details = $this->app->make(DetailsModel::class)(Movie::class);
-            $this->assertSame($defaults, $details);
-            $details = $this->app->make(DetailsModel::class)(MeiliMovie::class);
-            $this->assertSame($defaults, $details);
+        $classes = [
+            Movie::class      => $exception,
+            MeiliMovie::class => $expected,
+        ];
 
-            $action = $this->app->make(SynchronizesModels::class);
-            $action(array_keys($classes), function ($class, $result) use ($classes) {
-                if (\is_array($result)) {
-                    $this->assertSame($classes[$class], $result);
-                } else {
-                    $this->assertTrue($classes[$class] instanceof $result);
-                    $this->assertSame($classes[$class]->getMessage(), $result->getMessage());
-                }
-            });
+        $details = app()->make(DetailsModel::class)(Movie::class);
+        $this->assertSame($defaults, $details);
+        $details = app()->make(DetailsModel::class)(MeiliMovie::class);
+        $this->assertSame($defaults, $details);
 
-            $details = $this->app->make(DetailsModel::class)(Movie::class);
-            $this->assertSame($defaults, $details);
+        $action = app()->make(SynchronizesModels::class);
+        $action(array_keys($classes), function ($class, $result) use ($classes) {
+            if (\is_array($result)) {
+                $this->assertSame($classes[$class], $result);
+            } else {
+                $this->assertTrue($classes[$class] instanceof $result);
+                $this->assertSame($classes[$class]->getMessage(), $result->getMessage());
+            }
+        });
 
-            $details = $this->app->make(DetailsModel::class)(MeiliMovie::class);
-            $this->assertSame($settings, Arr::except($details, ['faceting', 'pagination', 'typoTolerance']));
-        } finally {
-            $this->deleteIndex(app(Movie::class)->searchableAs());
-            $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
-        }
+        $details = app()->make(DetailsModel::class)(Movie::class);
+        $this->assertSame($defaults, $details);
+
+        $details = app()->make(DetailsModel::class)(MeiliMovie::class);
+        $this->assertSame($settings, Arr::except($details, ['faceting', 'pagination', 'typoTolerance']));
+    } finally {
+        $this->deleteIndex(app(Movie::class)->searchableAs());
+        $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
     }
+});
 
-    /**
-     * Test SynchronizesModels::__invoke() method with pretend option.
-     */
-    public function test_with_pretend(): void
-    {
-        try {
-            $defaults = Helpers::defaultSettings(Helpers::engineVersion());
-            $settings = app(MeiliMovie::class)->meiliSettings();
-            $expected = collect($settings)
-                ->mapWithKeys(function ($value, $key) use ($defaults) {
-                    $old = $defaults[$key];
-                    $new = $value;
+/**
+ * Test SynchronizesModels::__invoke() method with pretend option.
+ */
+test('with pretend', function () {
+    try {
+        $defaults = Helpers::defaultSettings(Helpers::engineVersion());
+        $settings = app(MeiliMovie::class)->meiliSettings();
+        $expected = collect($settings)
+            ->mapWithKeys(function ($value, $key) use ($defaults) {
+                $old = $defaults[$key];
+                $new = $value;
 
-                    return [$key => $old === $new ? false : compact('old', 'new')];
-                })
-                ->filter()
-                ->all()
-            ;
+                return [$key => $old === $new ? false : compact('old', 'new')];
+            })
+            ->filter()
+            ->all()
+        ;
 
-            $details = $this->app->make(DetailsModel::class)(MeiliMovie::class);
-            $this->assertSame($defaults, $details);
+        $details = app()->make(DetailsModel::class)(MeiliMovie::class);
+        $this->assertSame($defaults, $details);
 
-            $action = $this->app->make(SynchronizesModels::class);
-            $action([MeiliMovie::class], function ($class, $result) use ($expected) {
-                $this->assertSame($expected, $result);
-            }, true);
+        $action = app()->make(SynchronizesModels::class);
+        $action([MeiliMovie::class], function ($class, $result) use ($expected) {
+            $this->assertSame($expected, $result);
+        }, true);
 
-            $details = $this->app->make(DetailsModel::class)(MeiliMovie::class);
-            $this->assertSame($defaults, $details);
-        } finally {
-            $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
-        }
+        $details = app()->make(DetailsModel::class)(MeiliMovie::class);
+        $this->assertSame($defaults, $details);
+    } finally {
+        $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
     }
-}
+});

--- a/tests/Actions/SynchronizesModelsTest.php
+++ b/tests/Actions/SynchronizesModelsTest.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use BadMethodCallException;
 use Dwarf\MeiliTools\Contracts\Actions\DetailsModel;
 use Dwarf\MeiliTools\Contracts\Actions\SynchronizesModels;
 use Dwarf\MeiliTools\Helpers;

--- a/tests/Actions/SynchronizesModelsTest.php
+++ b/tests/Actions/SynchronizesModelsTest.php
@@ -10,7 +10,6 @@ use Dwarf\MeiliTools\Tests\Models\Movie;
 use Dwarf\MeiliTools\Tests\TestCase;
 use Illuminate\Support\Arr;
 
-uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal

--- a/tests/Actions/ValidatesIndexSettingsTest.php
+++ b/tests/Actions/ValidatesIndexSettingsTest.php
@@ -11,7 +11,6 @@ use Illuminate\Support\Facades\App;
 use Illuminate\Support\Str;
 use MeiliSearch\MeiliSearch;
 
-uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal

--- a/tests/Actions/ValidatesIndexSettingsTest.php
+++ b/tests/Actions/ValidatesIndexSettingsTest.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-namespace Dwarf\MeiliTools\Tests\Actions;
-
 use Dwarf\MeiliTools\Contracts\Actions\ValidatesIndexSettings;
 use Dwarf\MeiliTools\Contracts\Rules\ArrayAssocRule;
 use Dwarf\MeiliTools\Helpers;
@@ -13,480 +11,474 @@ use Illuminate\Support\Facades\App;
 use Illuminate\Support\Str;
 use MeiliSearch\MeiliSearch;
 
+uses(Dwarf\MeiliTools\Tests\TestCase::class);
+
 /**
  * @internal
  */
-class ValidatesIndexSettingsTest extends TestCase
-{
-    /**
-     * Test ValidatesIndexSettings::rules() method.
-     */
-    public function test_rules(): void
-    {
-        $action = $this->app->make(ValidatesIndexSettings::class);
-        $version = Helpers::engineVersion() ?: '0.0.0';
 
-        $actual = $action->rules($version);
-        $expected = [
-            'displayedAttributes'    => ['sometimes', 'nullable', 'array', 'min:1'],
-            'displayedAttributes.*'  => ['required', 'string'],
-            'distinctAttribute'      => ['sometimes', 'nullable', 'string'],
-            'filterableAttributes'   => ['sometimes', 'nullable', 'array'],
-            'filterableAttributes.*' => ['required', 'string'],
-            'rankingRules'           => ['sometimes', 'nullable', 'array', 'min:1'],
-            'rankingRules.*'         => ['required', 'string'],
-            'searchableAttributes'   => ['sometimes', 'nullable', 'array', 'min:1'],
-            'searchableAttributes.*' => ['required', 'string'],
-            'sortableAttributes'     => ['sometimes', 'nullable', 'array'],
-            'sortableAttributes.*'   => ['required', 'string'],
-            'stopWords'              => ['sometimes', 'nullable', 'array'],
-            'stopWords.*'            => ['required', 'string'],
-            'synonyms'               => ['sometimes', 'nullable', $this->app->make(ArrayAssocRule::class)],
-            'synonyms.*'             => ['required', 'array'],
-            'synonyms.*.*'           => ['required', 'string'],
-            'typoTolerance'          => ['sometimes', 'nullable', $this->app->make(ArrayAssocRule::class)],
+/**
+ * Test ValidatesIndexSettings::rules() method.
+ */
+test('rules', function () {
+    $action = app()->make(ValidatesIndexSettings::class);
+    $version = Helpers::engineVersion() ?: '0.0.0';
+
+    $actual = $action->rules($version);
+    $expected = [
+        'displayedAttributes'    => ['sometimes', 'nullable', 'array', 'min:1'],
+        'displayedAttributes.*'  => ['required', 'string'],
+        'distinctAttribute'      => ['sometimes', 'nullable', 'string'],
+        'filterableAttributes'   => ['sometimes', 'nullable', 'array'],
+        'filterableAttributes.*' => ['required', 'string'],
+        'rankingRules'           => ['sometimes', 'nullable', 'array', 'min:1'],
+        'rankingRules.*'         => ['required', 'string'],
+        'searchableAttributes'   => ['sometimes', 'nullable', 'array', 'min:1'],
+        'searchableAttributes.*' => ['required', 'string'],
+        'sortableAttributes'     => ['sometimes', 'nullable', 'array'],
+        'sortableAttributes.*'   => ['required', 'string'],
+        'stopWords'              => ['sometimes', 'nullable', 'array'],
+        'stopWords.*'            => ['required', 'string'],
+        'synonyms'               => ['sometimes', 'nullable', app()->make(ArrayAssocRule::class)],
+        'synonyms.*'             => ['required', 'array'],
+        'synonyms.*.*'           => ['required', 'string'],
+        'typoTolerance'          => ['sometimes', 'nullable', app()->make(ArrayAssocRule::class)],
+    ];
+
+    // Add actual typo tolerance validation rules for engine version >=0.27.0.
+    if (version_compare($version, '0.27.0', '>=')) {
+        $expected['typoTolerance.enabled'] = ['sometimes', 'nullable', 'boolean'];
+        $expected['typoTolerance.minWordSizeForTypos'] = [
+            'sometimes',
+            'nullable',
+            app()->make(ArrayAssocRule::class),
         ];
-
-        // Add actual typo tolerance validation rules for engine version >=0.27.0.
-        if (version_compare($version, '0.27.0', '>=')) {
-            $expected['typoTolerance.enabled'] = ['sometimes', 'nullable', 'boolean'];
-            $expected['typoTolerance.minWordSizeForTypos'] = [
-                'sometimes',
-                'nullable',
-                $this->app->make(ArrayAssocRule::class),
-            ];
-            $expected['typoTolerance.minWordSizeForTypos.oneTypo'] = [
-                'sometimes',
-                'nullable',
-                'integer',
-                'between:0,255',
-            ];
-            $expected['typoTolerance.minWordSizeForTypos.twoTypos'] = [
-                'sometimes',
-                'nullable',
-                'integer',
-                'between:0,255',
-            ];
-            $expected['typoTolerance.disableOnWords'] = ['sometimes', 'nullable', 'array'];
-            $expected['typoTolerance.disableOnWords.*'] = ['required', 'string'];
-            $expected['typoTolerance.disableOnAttributes'] = ['sometimes', 'nullable', 'array'];
-            $expected['typoTolerance.disableOnAttributes.*'] = ['required', 'string'];
-        }
-
-        // Add faceting and pagination validation rules for engine version >=0.28.0.
-        if (version_compare($version, '0.28.0', '>=')) {
-            $expected['faceting'] = ['sometimes', 'nullable', $this->app->make(ArrayAssocRule::class)];
-            $expected['faceting.maxValuesPerFacet'] = ['sometimes', 'nullable', 'integer', 'min:0'];
-            $expected['pagination'] = ['sometimes', 'nullable', $this->app->make(ArrayAssocRule::class)];
-            $expected['pagination.maxTotalHits'] = ['sometimes', 'nullable', 'integer', 'min:0'];
-        }
-
-        $this->assertEquals($expected, $actual);
-    }
-
-    /**
-     * Test ValidatesIndexSettings::passes() method.
-     *
-     * @dataProvider passesProvider
-     *
-     * @param callable $data Callable with test data.
-     */
-    public function test_passes(callable $data): void
-    {
-        $action = $this->app->make(ValidatesIndexSettings::class);
-
-        [$value, $validated, $passes, $messages] = $data();
-
-        $actualPasses = $action->passes($value, Helpers::engineVersion());
-        $this->assertSame($passes, $actualPasses);
-
-        $actualValidated = $action->validated();
-        $this->assertSame($validated, $actualValidated);
-
-        $actualMessages = $action->messages();
-        $this->assertSame($messages, $actualMessages);
-    }
-
-    /**
-     * Test ValidatesIndexSettings::passes() method with typo tolerance.
-     *
-     * @dataProvider passesTypoToleranceProvider
-     *
-     * @param callable $data Callable with test data.
-     */
-    public function test_passes_typo_tolerance(callable $data): void
-    {
-        // Check if test should be run on this engine version.
-        $version = Helpers::engineVersion() ?: '0.0.0';
-        if (version_compare(MeiliSearch::VERSION, '0.23.2', '<') || version_compare($version, '0.27.0', '<')) {
-            $this->markTestSkipped('Typo tolerance is only available from 0.27.0 and up.');
-        }
-
-        $action = $this->app->make(ValidatesIndexSettings::class);
-
-        [$value, $validated, $passes, $messages] = $data();
-
-        $actualPasses = $action->passes($value, $version);
-        $this->assertSame($passes, $actualPasses);
-
-        $actualValidated = $action->validated();
-        $this->assertSame($validated, $actualValidated);
-
-        $actualMessages = $action->messages();
-        $this->assertSame($messages, $actualMessages);
-    }
-
-    /**
-     * Data provider for ValidateStylesAction::passes().
-     *
-     * Using yield for better overview, and closures so Laravel facades work during tests.
-     */
-    public function passesProvider(): iterable
-    {
-        $settings = Tools::movieSettings();
-
-        $fields = [
-            'displayedAttributes',
-            'filterableAttributes',
-            'rankingRules',
-            'searchableAttributes',
-            'sortableAttributes',
-            'stopWords',
+        $expected['typoTolerance.minWordSizeForTypos.oneTypo'] = [
+            'sometimes',
+            'nullable',
+            'integer',
+            'between:0,255',
         ];
+        $expected['typoTolerance.minWordSizeForTypos.twoTypos'] = [
+            'sometimes',
+            'nullable',
+            'integer',
+            'between:0,255',
+        ];
+        $expected['typoTolerance.disableOnWords'] = ['sometimes', 'nullable', 'array'];
+        $expected['typoTolerance.disableOnWords.*'] = ['required', 'string'];
+        $expected['typoTolerance.disableOnAttributes'] = ['sometimes', 'nullable', 'array'];
+        $expected['typoTolerance.disableOnAttributes.*'] = ['required', 'string'];
+    }
 
-        // Test successful validation of all fields.
+    // Add faceting and pagination validation rules for engine version >=0.28.0.
+    if (version_compare($version, '0.28.0', '>=')) {
+        $expected['faceting'] = ['sometimes', 'nullable', app()->make(ArrayAssocRule::class)];
+        $expected['faceting.maxValuesPerFacet'] = ['sometimes', 'nullable', 'integer', 'min:0'];
+        $expected['pagination'] = ['sometimes', 'nullable', app()->make(ArrayAssocRule::class)];
+        $expected['pagination.maxTotalHits'] = ['sometimes', 'nullable', 'integer', 'min:0'];
+    }
 
-        yield 'empty array' => [fn () => [[], [], true, []]];
+    $this->assertEquals($expected, $actual);
+});
 
-        foreach ($settings as $field => $value) {
-            $name = Str::of($field)->headline()->lower();
+/**
+ * Test ValidatesIndexSettings::passes() method.
+ *
+ *
+ * @param callable $data Callable with test data.
+ */
+test('passes', function (callable $data) {
+    $action = app()->make(ValidatesIndexSettings::class);
 
-            yield "{$name} valid" => [fn () => [
-                [$field => $settings[$field]],
-                [$field => $settings[$field]],
-                true,
-                [],
-            ]];
+    [$value, $validated, $passes, $messages] = $data();
 
-            yield "{$name} null" => [fn () => [[$field => null], [$field => null], true, []]];
-        }
+    $actualPasses = $action->passes($value, Helpers::engineVersion());
+    $this->assertSame($passes, $actualPasses);
 
-        // Test unsuccessful validation of all fields.
+    $actualValidated = $action->validated();
+    $this->assertSame($validated, $actualValidated);
 
-        foreach ($fields as $field) {
-            $name = Str::of($field)->headline()->lower();
+    $actualMessages = $action->messages();
+    $this->assertSame($messages, $actualMessages);
+})->with('passesProvider');
 
-            yield "{$name} not array" => [fn () => [
-                [$field => 42],
+/**
+ * Test ValidatesIndexSettings::passes() method with typo tolerance.
+ *
+ *
+ * @param callable $data Callable with test data.
+ */
+test('passes typo tolerance', function (callable $data) {
+    // Check if test should be run on this engine version.
+    $version = Helpers::engineVersion() ?: '0.0.0';
+    if (version_compare(MeiliSearch::VERSION, '0.23.2', '<') || version_compare($version, '0.27.0', '<')) {
+        $this->markTestSkipped('Typo tolerance is only available from 0.27.0 and up.');
+    }
+
+    $action = app()->make(ValidatesIndexSettings::class);
+
+    [$value, $validated, $passes, $messages] = $data();
+
+    $actualPasses = $action->passes($value, $version);
+    $this->assertSame($passes, $actualPasses);
+
+    $actualValidated = $action->validated();
+    $this->assertSame($validated, $actualValidated);
+
+    $actualMessages = $action->messages();
+    $this->assertSame($messages, $actualMessages);
+})->with('passesTypoToleranceProvider');
+
+// Datasets
+/**
+ * Data provider for ValidateStylesAction::passes().
+ *
+ * Using yield for better overview, and closures so Laravel facades work during tests.
+ */
+dataset('passesProvider', function () {
+    $settings = Tools::movieSettings();
+
+    $fields = [
+        'displayedAttributes',
+        'filterableAttributes',
+        'rankingRules',
+        'searchableAttributes',
+        'sortableAttributes',
+        'stopWords',
+    ];
+
+    // Test successful validation of all fields.
+
+    yield 'empty array' => [fn () => [[], [], true, []]];
+
+    foreach ($settings as $field => $value) {
+        $name = Str::of($field)->headline()->lower();
+
+        yield "{$name} valid" => [fn () => [
+            [$field => $settings[$field]],
+            [$field => $settings[$field]],
+            true,
+            [],
+        ]];
+
+        yield "{$name} null" => [fn () => [[$field => null], [$field => null], true, []]];
+    }
+
+    // Test unsuccessful validation of all fields.
+
+    foreach ($fields as $field) {
+        $name = Str::of($field)->headline()->lower();
+
+        yield "{$name} not array" => [fn () => [
+            [$field => 42],
+            null,
+            false,
+            [
+                $field => [
+                    __('validation.array', ['attribute' => $name]),
+                ],
+            ],
+        ]];
+
+        if (\in_array($field, ['displayedAttributes', 'rankingRules', 'searchableAttributes'])) {
+            yield "{$name} empty error" => [fn () => [
+                [$field => []],
                 null,
                 false,
                 [
                     $field => [
-                        __('validation.array', ['attribute' => $name]),
-                    ],
-                ],
-            ]];
-
-            if (\in_array($field, ['displayedAttributes', 'rankingRules', 'searchableAttributes'])) {
-                yield "{$name} empty error" => [fn () => [
-                    [$field => []],
-                    null,
-                    false,
-                    [
-                        $field => [
-                            __('validation.min.array', ['attribute' => $name, 'min' => 1]),
-                        ],
-                    ],
-                ]];
-            }
-
-            yield "{$name} required error" => [fn () => [
-                [$field => [null]],
-                null,
-                false,
-                [
-                    $field . '.0' => [
-                        __('validation.required', ['attribute' => $field . '.0']),
-                    ],
-                ],
-            ]];
-
-            yield "{$name} string error" => [fn () => [
-                [$field => [42]],
-                null,
-                false,
-                [
-                    $field . '.0' => [
-                        __('validation.string', ['attribute' => $field . '.0']),
+                        __('validation.min.array', ['attribute' => $name, 'min' => 1]),
                     ],
                 ],
             ]];
         }
 
-        yield 'distinct attribute string error' => [fn () => [
-            ['distinctAttribute' => 42],
+        yield "{$name} required error" => [fn () => [
+            [$field => [null]],
             null,
             false,
             [
-                'distinctAttribute' => [
-                    __('validation.string', ['attribute' => 'distinct attribute']),
+                $field . '.0' => [
+                    __('validation.required', ['attribute' => $field . '.0']),
                 ],
             ],
         ]];
 
-        yield 'synonyms not array nor assoc' => [fn () => [
-            ['synonyms' => 42],
+        yield "{$name} string error" => [fn () => [
+            [$field => [42]],
             null,
             false,
             [
-                'synonyms' => [
-                    Str::replace(':attribute', 'synonyms', App::make(ArrayAssocRule::class)->message()),
-                ],
-            ],
-        ]];
-
-        yield 'synonyms array not assoc' => [fn () => [
-            ['synonyms' => [42]],
-            null,
-            false,
-            [
-                'synonyms' => [
-                    Str::replace(':attribute', 'synonyms', App::make(ArrayAssocRule::class)->message()),
-                ],
-                'synonyms.0' => [
-                    __('validation.array', ['attribute' => 'synonyms.0']),
-                ],
-            ],
-        ]];
-
-        yield 'synonyms foo required error' => [fn () => [
-            ['synonyms' => ['foo' => null]],
-            null,
-            false,
-            [
-                'synonyms.foo' => [
-                    __('validation.required', ['attribute' => 'synonyms.foo']),
-                ],
-            ],
-        ]];
-
-        yield 'synonyms foo array error' => [fn () => [
-            ['synonyms' => ['foo' => 42]],
-            null,
-            false,
-            [
-                'synonyms.foo' => [
-                    __('validation.array', ['attribute' => 'synonyms.foo']),
-                ],
-            ],
-        ]];
-
-        yield 'synonyms foo zero required error' => [fn () => [
-            ['synonyms' => ['foo' => [null]]],
-            null,
-            false,
-            [
-                'synonyms.foo.0' => [
-                    __('validation.required', ['attribute' => 'synonyms.foo.0']),
-                ],
-            ],
-        ]];
-
-        yield 'synonyms foo zero string error' => [fn () => [
-            ['synonyms' => ['foo' => [42]]],
-            null,
-            false,
-            [
-                'synonyms.foo.0' => [
-                    __('validation.string', ['attribute' => 'synonyms.foo.0']),
-                ],
-            ],
-        ]];
-
-        yield 'typo tolerance not array nor assoc' => [fn () => [
-            ['typoTolerance' => 42],
-            null,
-            false,
-            [
-                'typoTolerance' => [
-                    Str::replace(':attribute', 'typo tolerance', App::make(ArrayAssocRule::class)->message()),
-                ],
-            ],
-        ]];
-
-        yield 'typo tolerance array not assoc' => [fn () => [
-            ['typoTolerance' => [42]],
-            null,
-            false,
-            [
-                'typoTolerance' => [
-                    Str::replace(':attribute', 'typo tolerance', App::make(ArrayAssocRule::class)->message()),
+                $field . '.0' => [
+                    __('validation.string', ['attribute' => $field . '.0']),
                 ],
             ],
         ]];
     }
 
-    /**
-     * Data provider for ValidateStylesAction::passes().
-     *
-     * Using yield for better overview, and closures so Laravel facades work during tests.
-     */
-    public function passesTypoToleranceProvider(): iterable
-    {
-        $field = 'typoTolerance';
-        $name = Str::of($field)->headline()->lower();
-
-        $props = ['enabled', 'minWordSizeForTypos', 'disableOnWords', 'disableOnAttributes'];
-
-        $settings = [
-            'enabled'             => true,
-            'minWordSizeForTypos' => [
-                'oneTypo'  => 2,
-                'twoTypos' => 2,
+    yield 'distinct attribute string error' => [fn () => [
+        ['distinctAttribute' => 42],
+        null,
+        false,
+        [
+            'distinctAttribute' => [
+                __('validation.string', ['attribute' => 'distinct attribute']),
             ],
-            'disableOnWords'      => ['foo', 'bar'],
-            'disableOnAttributes' => ['foo', 'bar'],
-        ];
+        ],
+    ]];
 
-        yield "{$name} valid" => [fn () => [[$field => $settings], [$field => $settings], true, []]];
+    yield 'synonyms not array nor assoc' => [fn () => [
+        ['synonyms' => 42],
+        null,
+        false,
+        [
+            'synonyms' => [
+                Str::replace(':attribute', 'synonyms', App::make(ArrayAssocRule::class)->message()),
+            ],
+        ],
+    ]];
 
-        yield "{$name} null" => [fn () => [[$field => null], [$field => null], true, []]];
+    yield 'synonyms array not assoc' => [fn () => [
+        ['synonyms' => [42]],
+        null,
+        false,
+        [
+            'synonyms' => [
+                Str::replace(':attribute', 'synonyms', App::make(ArrayAssocRule::class)->message()),
+            ],
+            'synonyms.0' => [
+                __('validation.array', ['attribute' => 'synonyms.0']),
+            ],
+        ],
+    ]];
 
-        foreach (array_keys($settings) as $prop) {
-            $name = Str::of("{$field}.{$prop}")->headline()->replace('.', ' ')->lower();
+    yield 'synonyms foo required error' => [fn () => [
+        ['synonyms' => ['foo' => null]],
+        null,
+        false,
+        [
+            'synonyms.foo' => [
+                __('validation.required', ['attribute' => 'synonyms.foo']),
+            ],
+        ],
+    ]];
 
-            yield "{$name} null" => [fn () => [
-                [$field => [$prop => null]],
-                [$field => [$prop => null]],
-                true,
-                [],
-            ]];
+    yield 'synonyms foo array error' => [fn () => [
+        ['synonyms' => ['foo' => 42]],
+        null,
+        false,
+        [
+            'synonyms.foo' => [
+                __('validation.array', ['attribute' => 'synonyms.foo']),
+            ],
+        ],
+    ]];
 
-            if ($prop === 'minWordSizeForTypos') {
-                foreach (['oneTypo', 'twoTypos'] as $size) {
-                    $name = Str::of("{$field}.{$prop}.{$size}")->headline()->replace('.', ' ')->lower();
+    yield 'synonyms foo zero required error' => [fn () => [
+        ['synonyms' => ['foo' => [null]]],
+        null,
+        false,
+        [
+            'synonyms.foo.0' => [
+                __('validation.required', ['attribute' => 'synonyms.foo.0']),
+            ],
+        ],
+    ]];
 
-                    yield "{$name} null" => [fn () => [
-                        [$field => [$prop => [$size => null]]],
-                        [$field => [$prop => [$size => null]]],
-                        true,
-                        [],
-                    ]];
-                }
-            }
-        }
+    yield 'synonyms foo zero string error' => [fn () => [
+        ['synonyms' => ['foo' => [42]]],
+        null,
+        false,
+        [
+            'synonyms.foo.0' => [
+                __('validation.string', ['attribute' => 'synonyms.foo.0']),
+            ],
+        ],
+    ]];
 
-        $prop = 'enabled';
+    yield 'typo tolerance not array nor assoc' => [fn () => [
+        ['typoTolerance' => 42],
+        null,
+        false,
+        [
+            'typoTolerance' => [
+                Str::replace(':attribute', 'typo tolerance', App::make(ArrayAssocRule::class)->message()),
+            ],
+        ],
+    ]];
+
+    yield 'typo tolerance array not assoc' => [fn () => [
+        ['typoTolerance' => [42]],
+        null,
+        false,
+        [
+            'typoTolerance' => [
+                Str::replace(':attribute', 'typo tolerance', App::make(ArrayAssocRule::class)->message()),
+            ],
+        ],
+    ]];
+});
+
+/**
+ * Data provider for ValidateStylesAction::passes().
+ *
+ * Using yield for better overview, and closures so Laravel facades work during tests.
+ */
+dataset('passesTypoToleranceProvider', function () {
+    $field = 'typoTolerance';
+    $name = Str::of($field)->headline()->lower();
+
+    $props = ['enabled', 'minWordSizeForTypos', 'disableOnWords', 'disableOnAttributes'];
+
+    $settings = [
+        'enabled'             => true,
+        'minWordSizeForTypos' => [
+            'oneTypo'  => 2,
+            'twoTypos' => 2,
+        ],
+        'disableOnWords'      => ['foo', 'bar'],
+        'disableOnAttributes' => ['foo', 'bar'],
+    ];
+
+    yield "{$name} valid" => [fn () => [[$field => $settings], [$field => $settings], true, []]];
+
+    yield "{$name} null" => [fn () => [[$field => null], [$field => null], true, []]];
+
+    foreach (array_keys($settings) as $prop) {
         $name = Str::of("{$field}.{$prop}")->headline()->replace('.', ' ')->lower();
 
-        yield "{$name} boolean error" => [fn () => [
-            [$field => ['enabled' => 42]],
+        yield "{$name} null" => [fn () => [
+            [$field => [$prop => null]],
+            [$field => [$prop => null]],
+            true,
+            [],
+        ]];
+
+        if ($prop === 'minWordSizeForTypos') {
+            foreach (['oneTypo', 'twoTypos'] as $size) {
+                $name = Str::of("{$field}.{$prop}.{$size}")->headline()->replace('.', ' ')->lower();
+
+                yield "{$name} null" => [fn () => [
+                    [$field => [$prop => [$size => null]]],
+                    [$field => [$prop => [$size => null]]],
+                    true,
+                    [],
+                ]];
+            }
+        }
+    }
+
+    $prop = 'enabled';
+    $name = Str::of("{$field}.{$prop}")->headline()->replace('.', ' ')->lower();
+
+    yield "{$name} boolean error" => [fn () => [
+        [$field => ['enabled' => 42]],
+        null,
+        false,
+        [
+            "{$field}.{$prop}" => [
+                __('validation.boolean', ['attribute' => $name]),
+            ],
+        ],
+    ]];
+
+    $prop = 'minWordSizeForTypos';
+    $name = Str::of("{$field}.{$prop}")->headline()->replace('.', ' ')->lower();
+
+    yield "{$name} not array nor assoc" => [fn () => [
+        [$field => [$prop => 42]],
+        null,
+        false,
+        [
+            "{$field}.{$prop}" => [
+                Str::replace(':attribute', $name, App::make(ArrayAssocRule::class)->message()),
+            ],
+        ],
+    ]];
+
+    yield "{$name} array not assoc" => [fn () => [
+        [$field => [$prop => [42]]],
+        null,
+        false,
+        [
+            "{$field}.{$prop}" => [
+                Str::replace(':attribute', $name, App::make(ArrayAssocRule::class)->message()),
+            ],
+        ],
+    ]];
+
+    foreach (['oneTypo', 'twoTypos'] as $size) {
+        $name = Str::of("{$field}.{$prop}.{$size}")->headline()->replace('.', ' ')->lower();
+
+        yield "{$name} integer error" => [fn () => [
+            [$field => [$prop => [$size => 'foo']]],
             null,
             false,
             [
-                "{$field}.{$prop}" => [
-                    __('validation.boolean', ['attribute' => $name]),
+                "{$field}.{$prop}.{$size}" => [
+                    __('validation.integer', ['attribute' => $name]),
                 ],
             ],
         ]];
 
-        $prop = 'minWordSizeForTypos';
+        yield "{$name} between error low" => [fn () => [
+            [$field => [$prop => [$size => -1]]],
+            null,
+            false,
+            [
+                "{$field}.{$prop}.{$size}" => [
+                    __('validation.between.numeric', ['attribute' => $name, 'min' => 0, 'max' => 255]),
+                ],
+            ],
+        ]];
+
+        yield "{$name} between error high" => [fn () => [
+            [$field => [$prop => [$size => 300]]],
+            null,
+            false,
+            [
+                "{$field}.{$prop}.{$size}" => [
+                    __('validation.between.numeric', ['attribute' => $name, 'min' => 0, 'max' => 255]),
+                ],
+            ],
+        ]];
+    }
+
+    foreach (['disableOnWords', 'disableOnAttributes'] as $prop) {
         $name = Str::of("{$field}.{$prop}")->headline()->replace('.', ' ')->lower();
 
-        yield "{$name} not array nor assoc" => [fn () => [
+        yield "{$name} not array" => [fn () => [
             [$field => [$prop => 42]],
             null,
             false,
             [
                 "{$field}.{$prop}" => [
-                    Str::replace(':attribute', $name, App::make(ArrayAssocRule::class)->message()),
+                    __('validation.array', ['attribute' => $name]),
                 ],
             ],
         ]];
 
-        yield "{$name} array not assoc" => [fn () => [
+        yield "{$name} required error" => [fn () => [
+            [$field => [$prop => [null]]],
+            null,
+            false,
+            [
+                "{$field}.{$prop}.0" => [
+                    __('validation.required', ['attribute' => "{$field}.{$prop}.0"]),
+                ],
+            ],
+        ]];
+
+        yield "{$name} string error" => [fn () => [
             [$field => [$prop => [42]]],
             null,
             false,
             [
-                "{$field}.{$prop}" => [
-                    Str::replace(':attribute', $name, App::make(ArrayAssocRule::class)->message()),
+                "{$field}.{$prop}.0" => [
+                    __('validation.string', ['attribute' => "{$field}.{$prop}.0"]),
                 ],
             ],
         ]];
-
-        foreach (['oneTypo', 'twoTypos'] as $size) {
-            $name = Str::of("{$field}.{$prop}.{$size}")->headline()->replace('.', ' ')->lower();
-
-            yield "{$name} integer error" => [fn () => [
-                [$field => [$prop => [$size => 'foo']]],
-                null,
-                false,
-                [
-                    "{$field}.{$prop}.{$size}" => [
-                        __('validation.integer', ['attribute' => $name]),
-                    ],
-                ],
-            ]];
-
-            yield "{$name} between error low" => [fn () => [
-                [$field => [$prop => [$size => -1]]],
-                null,
-                false,
-                [
-                    "{$field}.{$prop}.{$size}" => [
-                        __('validation.between.numeric', ['attribute' => $name, 'min' => 0, 'max' => 255]),
-                    ],
-                ],
-            ]];
-
-            yield "{$name} between error high" => [fn () => [
-                [$field => [$prop => [$size => 300]]],
-                null,
-                false,
-                [
-                    "{$field}.{$prop}.{$size}" => [
-                        __('validation.between.numeric', ['attribute' => $name, 'min' => 0, 'max' => 255]),
-                    ],
-                ],
-            ]];
-        }
-
-        foreach (['disableOnWords', 'disableOnAttributes'] as $prop) {
-            $name = Str::of("{$field}.{$prop}")->headline()->replace('.', ' ')->lower();
-
-            yield "{$name} not array" => [fn () => [
-                [$field => [$prop => 42]],
-                null,
-                false,
-                [
-                    "{$field}.{$prop}" => [
-                        __('validation.array', ['attribute' => $name]),
-                    ],
-                ],
-            ]];
-
-            yield "{$name} required error" => [fn () => [
-                [$field => [$prop => [null]]],
-                null,
-                false,
-                [
-                    "{$field}.{$prop}.0" => [
-                        __('validation.required', ['attribute' => "{$field}.{$prop}.0"]),
-                    ],
-                ],
-            ]];
-
-            yield "{$name} string error" => [fn () => [
-                [$field => [$prop => [42]]],
-                null,
-                false,
-                [
-                    "{$field}.{$prop}.0" => [
-                        __('validation.string', ['attribute' => "{$field}.{$prop}.0"]),
-                    ],
-                ],
-            ]];
-        }
     }
-}
+});

--- a/tests/Actions/ValidatesIndexSettingsTest.php
+++ b/tests/Actions/ValidatesIndexSettingsTest.php
@@ -79,7 +79,7 @@ test('rules', function () {
         $expected['pagination.maxTotalHits'] = ['sometimes', 'nullable', 'integer', 'min:0'];
     }
 
-    $this->assertEquals($expected, $actual);
+    expect($actual)->toEqual($expected);
 });
 
 /**
@@ -94,13 +94,13 @@ test('passes', function (callable $data) {
     [$value, $validated, $passes, $messages] = $data();
 
     $actualPasses = $action->passes($value, Helpers::engineVersion());
-    $this->assertSame($passes, $actualPasses);
+    expect($actualPasses)->toBe($passes);
 
     $actualValidated = $action->validated();
-    $this->assertSame($validated, $actualValidated);
+    expect($actualValidated)->toBe($validated);
 
     $actualMessages = $action->messages();
-    $this->assertSame($messages, $actualMessages);
+    expect($actualMessages)->toBe($messages);
 })->with('passesProvider');
 
 /**
@@ -121,13 +121,13 @@ test('passes typo tolerance', function (callable $data) {
     [$value, $validated, $passes, $messages] = $data();
 
     $actualPasses = $action->passes($value, $version);
-    $this->assertSame($passes, $actualPasses);
+    expect($actualPasses)->toBe($passes);
 
     $actualValidated = $action->validated();
-    $this->assertSame($validated, $actualValidated);
+    expect($actualValidated)->toBe($validated);
 
     $actualMessages = $action->messages();
-    $this->assertSame($messages, $actualMessages);
+    expect($actualMessages)->toBe($messages);
 })->with('passesTypoToleranceProvider');
 
 // Datasets

--- a/tests/Actions/ValidatesIndexSettingsTest.php
+++ b/tests/Actions/ValidatesIndexSettingsTest.php
@@ -5,12 +5,10 @@ declare(strict_types=1);
 use Dwarf\MeiliTools\Contracts\Actions\ValidatesIndexSettings;
 use Dwarf\MeiliTools\Contracts\Rules\ArrayAssocRule;
 use Dwarf\MeiliTools\Helpers;
-use Dwarf\MeiliTools\Tests\TestCase;
 use Dwarf\MeiliTools\Tests\Tools;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Str;
 use MeiliSearch\MeiliSearch;
-
 
 /**
  * @internal

--- a/tests/Actions/ViewsIndexTest.php
+++ b/tests/Actions/ViewsIndexTest.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 use Dwarf\MeiliTools\Contracts\Actions\ViewsIndex;
 use Dwarf\MeiliTools\Exceptions\MeiliToolsException;
-use Dwarf\MeiliTools\Tests\TestCase;
 use Illuminate\Testing\Fluent\AssertableJson;
 use MeiliSearch\Exceptions\ApiException;
 use MeiliSearch\Exceptions\CommunicationException;
-
 
 /**
  * @internal

--- a/tests/Actions/ViewsIndexTest.php
+++ b/tests/Actions/ViewsIndexTest.php
@@ -9,7 +9,6 @@ use Illuminate\Testing\Fluent\AssertableJson;
 use MeiliSearch\Exceptions\ApiException;
 use MeiliSearch\Exceptions\CommunicationException;
 
-uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal

--- a/tests/Actions/ViewsModelTest.php
+++ b/tests/Actions/ViewsModelTest.php
@@ -7,7 +7,6 @@ use Dwarf\MeiliTools\Tests\Models\Movie;
 use Dwarf\MeiliTools\Tests\TestCase;
 use Illuminate\Testing\Fluent\AssertableJson;
 
-uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal

--- a/tests/Actions/ViewsModelTest.php
+++ b/tests/Actions/ViewsModelTest.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 use Dwarf\MeiliTools\Contracts\Actions\ViewsModel;
 use Dwarf\MeiliTools\Tests\Models\Movie;
-use Dwarf\MeiliTools\Tests\TestCase;
 use Illuminate\Testing\Fluent\AssertableJson;
-
 
 /**
  * @internal

--- a/tests/Actions/ViewsModelTest.php
+++ b/tests/Actions/ViewsModelTest.php
@@ -2,66 +2,62 @@
 
 declare(strict_types=1);
 
-namespace Dwarf\MeiliTools\Tests\Actions;
-
 use Dwarf\MeiliTools\Contracts\Actions\ViewsModel;
 use Dwarf\MeiliTools\Tests\Models\Movie;
 use Dwarf\MeiliTools\Tests\TestCase;
 use Illuminate\Testing\Fluent\AssertableJson;
 
+uses(Dwarf\MeiliTools\Tests\TestCase::class);
+
 /**
  * @internal
  */
-class ViewsModelTest extends TestCase
-{
-    /**
-     * Test ViewsModel::__invoke() method.
-     */
-    public function test_invoke(): void
-    {
-        $model = app(Movie::class);
-        $index = $model->searchableAs();
-        $primaryKey = $model->getKeyName();
 
-        try {
-            $info = $this->app->make(ViewsModel::class)(Movie::class);
+/**
+ * Test ViewsModel::__invoke() method.
+ */
+test('invoke', function () {
+    $model = app(Movie::class);
+    $index = $model->searchableAs();
+    $primaryKey = $model->getKeyName();
 
-            AssertableJson::fromArray($info)
-                ->where('uid', $index)
-                ->where('primaryKey', $primaryKey)
-                ->whereType('createdAt', 'string')
-                ->whereType('updatedAt', 'string')
-                ->interacted()
-            ;
-        } finally {
-            $this->deleteIndex($index);
-        }
+    try {
+        $info = app()->make(ViewsModel::class)(Movie::class);
+
+        AssertableJson::fromArray($info)
+            ->where('uid', $index)
+            ->where('primaryKey', $primaryKey)
+            ->whereType('createdAt', 'string')
+            ->whereType('updatedAt', 'string')
+            ->interacted()
+        ;
+    } finally {
+        $this->deleteIndex($index);
     }
+});
 
-    /**
-     * Test ViewsModel::__invoke() method with stats.
-     */
-    public function test_invoke_with_stats(): void
-    {
-        $model = app(Movie::class);
-        $index = $model->searchableAs();
-        $primaryKey = $model->getKeyName();
+/**
+ * Test ViewsModel::__invoke() method with stats.
+ */
+test('invoke with stats', function () {
+    $model = app(Movie::class);
+    $index = $model->searchableAs();
+    $primaryKey = $model->getKeyName();
 
-        try {
-            $info = $this->app->make(ViewsModel::class)(Movie::class, true);
+    try {
+        $info = app()->make(ViewsModel::class)(Movie::class, true);
 
-            AssertableJson::fromArray($info)
-                ->where('uid', $index)
-                ->where('primaryKey', $primaryKey)
-                ->whereType('createdAt', 'string')
-                ->whereType('updatedAt', 'string')
-                ->where('numberOfDocuments', 0)
-                ->where('isIndexing', false)
-                ->etc()
-                ->interacted()
-            ;
-        } finally {
-            $this->deleteIndex($index);
-        }
+        AssertableJson::fromArray($info)
+            ->where('uid', $index)
+            ->where('primaryKey', $primaryKey)
+            ->whereType('createdAt', 'string')
+            ->whereType('updatedAt', 'string')
+            ->where('numberOfDocuments', 0)
+            ->where('isIndexing', false)
+            ->etc()
+            ->interacted()
+        ;
+    } finally {
+        $this->deleteIndex($index);
     }
-}
+});

--- a/tests/Commands/IndexCreateTest.php
+++ b/tests/Commands/IndexCreateTest.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use Dwarf\MeiliTools\Tests\TestCase;
 
 
 /**

--- a/tests/Commands/IndexCreateTest.php
+++ b/tests/Commands/IndexCreateTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Dwarf\MeiliTools\Tests\TestCase;
 
-uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal

--- a/tests/Commands/IndexCreateTest.php
+++ b/tests/Commands/IndexCreateTest.php
@@ -2,42 +2,32 @@
 
 declare(strict_types=1);
 
-namespace Dwarf\MeiliTools\Tests\Commands;
-
 use Dwarf\MeiliTools\Tests\TestCase;
+
+uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal
  */
-class IndexCreateTest extends TestCase
-{
-    /**
-     * Test index.
-     *
-     * @var string
-     */
-    private const INDEX = 'testing-create-index';
 
-    /**
-     * Test `meili:index:create` command with default settings.
-     */
-    public function test_with_default_settings(): void
-    {
-        try {
-            $this->artisan('meili:index:create')
-                ->expectsQuestion('What is the index name?', self::INDEX)
-                ->assertSuccessful()
-            ;
-        } finally {
-            $this->deleteIndex(self::INDEX);
-        }
-
-        try {
-            $this->artisan('meili:index:create', ['index' => self::INDEX])
-                ->assertSuccessful()
-            ;
-        } finally {
-            $this->deleteIndex(self::INDEX);
-        }
+/**
+ * Test `meili:index:create` command with default settings.
+ */
+test('with default settings', function () {
+    try {
+        $this->artisan('meili:index:create')
+            ->expectsQuestion('What is the index name?', self::INDEX)
+            ->assertSuccessful()
+        ;
+    } finally {
+        $this->deleteIndex(self::INDEX);
     }
-}
+
+    try {
+        $this->artisan('meili:index:create', ['index' => self::INDEX])
+            ->assertSuccessful()
+        ;
+    } finally {
+        $this->deleteIndex(self::INDEX);
+    }
+});

--- a/tests/Commands/IndexDeleteTest.php
+++ b/tests/Commands/IndexDeleteTest.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use Dwarf\MeiliTools\Tests\TestCase;
 
 
 /**

--- a/tests/Commands/IndexDeleteTest.php
+++ b/tests/Commands/IndexDeleteTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Dwarf\MeiliTools\Tests\TestCase;
 
-uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal

--- a/tests/Commands/IndexDeleteTest.php
+++ b/tests/Commands/IndexDeleteTest.php
@@ -2,69 +2,57 @@
 
 declare(strict_types=1);
 
-namespace Dwarf\MeiliTools\Tests\Commands;
-
 use Dwarf\MeiliTools\Tests\TestCase;
+
+uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal
  */
-class IndexDeleteTest extends TestCase
-{
-    /**
-     * Test index.
-     *
-     * @var string
-     */
-    private const INDEX = 'testing-delete-index';
 
-    /**
-     * Test `meili:index:delete` command with default settings.
-     */
-    public function test_with_default_settings(): void
-    {
-        $this->withIndex(self::INDEX, function () {
-            $this->artisan('meili:index:delete')
-                ->expectsQuestion('What is the index name?', self::INDEX)
-                ->expectsConfirmation('Are you sure you want to run this command?', 'no')
-                ->assertFailed()
-            ;
+/**
+ * Test `meili:index:delete` command with default settings.
+ */
+test('with default settings', function () {
+    $this->withIndex(self::INDEX, function () {
+        $this->artisan('meili:index:delete')
+            ->expectsQuestion('What is the index name?', self::INDEX)
+            ->expectsConfirmation('Are you sure you want to run this command?', 'no')
+            ->assertFailed()
+        ;
 
-            $this->artisan('meili:index:delete')
-                ->expectsQuestion('What is the index name?', self::INDEX)
-                ->expectsConfirmation('Are you sure you want to run this command?', 'yes')
-                ->assertSuccessful()
-            ;
-        });
-    }
+        $this->artisan('meili:index:delete')
+            ->expectsQuestion('What is the index name?', self::INDEX)
+            ->expectsConfirmation('Are you sure you want to run this command?', 'yes')
+            ->assertSuccessful()
+        ;
+    });
+});
 
-    /**
-     * Test `meili:index:delete` command with specified name.
-     */
-    public function test_with_specified_name(): void
-    {
-        $this->withIndex(self::INDEX, function () {
-            $this->artisan('meili:index:delete', ['index' => self::INDEX])
-                ->expectsConfirmation('Are you sure you want to run this command?', 'no')
-                ->assertFailed()
-            ;
+/**
+ * Test `meili:index:delete` command with specified name.
+ */
+test('with specified name', function () {
+    $this->withIndex(self::INDEX, function () {
+        $this->artisan('meili:index:delete', ['index' => self::INDEX])
+            ->expectsConfirmation('Are you sure you want to run this command?', 'no')
+            ->assertFailed()
+        ;
 
-            $this->artisan('meili:index:delete', ['index' => self::INDEX])
-                ->expectsConfirmation('Are you sure you want to run this command?', 'yes')
-                ->assertSuccessful()
-            ;
-        });
-    }
+        $this->artisan('meili:index:delete', ['index' => self::INDEX])
+            ->expectsConfirmation('Are you sure you want to run this command?', 'yes')
+            ->assertSuccessful()
+        ;
+    });
+});
 
-    /**
-     * Test `meili:index:delete` command with force option.
-     */
-    public function test_with_force_option(): void
-    {
-        $this->withIndex(self::INDEX, function () {
-            $this->artisan('meili:index:delete', ['index' => self::INDEX, '--force' => true])
-                ->assertSuccessful()
-            ;
-        });
-    }
-}
+/**
+ * Test `meili:index:delete` command with force option.
+ */
+test('with force option', function () {
+    $this->withIndex(self::INDEX, function () {
+        $this->artisan('meili:index:delete', ['index' => self::INDEX, '--force' => true])
+            ->assertSuccessful()
+        ;
+    });
+});

--- a/tests/Commands/IndexDetailsTest.php
+++ b/tests/Commands/IndexDetailsTest.php
@@ -8,7 +8,6 @@ use Dwarf\MeiliTools\Tests\TestCase;
 use Dwarf\MeiliTools\Tests\Tools;
 use Illuminate\Support\Arr;
 
-uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal

--- a/tests/Commands/IndexDetailsTest.php
+++ b/tests/Commands/IndexDetailsTest.php
@@ -2,67 +2,56 @@
 
 declare(strict_types=1);
 
-namespace Dwarf\MeiliTools\Tests\Commands;
-
 use Dwarf\MeiliTools\Contracts\Actions\SynchronizesIndex;
 use Dwarf\MeiliTools\Helpers;
 use Dwarf\MeiliTools\Tests\TestCase;
 use Dwarf\MeiliTools\Tests\Tools;
 use Illuminate\Support\Arr;
 
+uses(Dwarf\MeiliTools\Tests\TestCase::class);
+
 /**
  * @internal
  */
-class IndexDetailsTest extends TestCase
-{
-    /**
-     * Test index.
-     *
-     * @var string
-     */
-    private const INDEX = 'testing-details-index';
 
-    /**
-     * Test `meili:index:details` command with default settings.
-     */
-    public function test_with_default_settings(): void
-    {
-        $this->withIndex(self::INDEX, function () {
-            $values = Helpers::convertIndexDataToTable(Helpers::defaultSettings(Helpers::engineVersion()));
+/**
+ * Test `meili:index:details` command with default settings.
+ */
+test('with default settings', function () {
+    $this->withIndex(self::INDEX, function () {
+        $values = Helpers::convertIndexDataToTable(Helpers::defaultSettings(Helpers::engineVersion()));
 
-            $this->artisan('meili:index:details')
-                ->expectsQuestion('What is the index name?', self::INDEX)
-                ->expectsTable(['Setting', 'Value'], $values)
-                ->assertSuccessful()
-            ;
+        $this->artisan('meili:index:details')
+            ->expectsQuestion('What is the index name?', self::INDEX)
+            ->expectsTable(['Setting', 'Value'], $values)
+            ->assertSuccessful()
+        ;
 
-            $this->artisan('meili:index:details', ['index' => self::INDEX])
-                ->expectsTable(['Setting', 'Value'], $values)
-                ->assertSuccessful()
-            ;
-        });
-    }
+        $this->artisan('meili:index:details', ['index' => self::INDEX])
+            ->expectsTable(['Setting', 'Value'], $values)
+            ->assertSuccessful()
+        ;
+    });
+});
 
-    /**
-     * Test `meili:index:details` command with advanced settings.
-     */
-    public function test_with_advanced_settings(): void
-    {
-        $this->withIndex(self::INDEX, function () {
-            $defaults = Helpers::defaultSettings(Helpers::engineVersion());
-            $settings = Tools::movieSettings();
+/**
+ * Test `meili:index:details` command with advanced settings.
+ */
+test('with advanced settings', function () {
+    $this->withIndex(self::INDEX, function () {
+        $defaults = Helpers::defaultSettings(Helpers::engineVersion());
+        $settings = Tools::movieSettings();
 
-            $changes = $this->app->make(SynchronizesIndex::class)(self::INDEX, $settings);
-            $this->assertNotEmpty($changes);
+        $changes = app()->make(SynchronizesIndex::class)(self::INDEX, $settings);
+        $this->assertNotEmpty($changes);
 
-            $values = Helpers::convertIndexDataToTable(
-                Helpers::sortSettings($settings + Arr::only($defaults, ['faceting', 'pagination', 'typoTolerance']))
-            );
+        $values = Helpers::convertIndexDataToTable(
+            Helpers::sortSettings($settings + Arr::only($defaults, ['faceting', 'pagination', 'typoTolerance']))
+        );
 
-            $this->artisan('meili:index:details', ['index' => self::INDEX])
-                ->expectsTable(['Setting', 'Value'], $values)
-                ->assertSuccessful()
-            ;
-        });
-    }
-}
+        $this->artisan('meili:index:details', ['index' => self::INDEX])
+            ->expectsTable(['Setting', 'Value'], $values)
+            ->assertSuccessful()
+        ;
+    });
+});

--- a/tests/Commands/IndexDetailsTest.php
+++ b/tests/Commands/IndexDetailsTest.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 use Dwarf\MeiliTools\Contracts\Actions\SynchronizesIndex;
 use Dwarf\MeiliTools\Helpers;
-use Dwarf\MeiliTools\Tests\TestCase;
 use Dwarf\MeiliTools\Tests\Tools;
 use Illuminate\Support\Arr;
-
 
 /**
  * @internal

--- a/tests/Commands/IndexResetTest.php
+++ b/tests/Commands/IndexResetTest.php
@@ -2,101 +2,90 @@
 
 declare(strict_types=1);
 
-namespace Dwarf\MeiliTools\Tests\Commands;
-
 use Dwarf\MeiliTools\Contracts\Actions\DetailsIndex;
 use Dwarf\MeiliTools\Contracts\Actions\SynchronizesIndex;
 use Dwarf\MeiliTools\Helpers;
 use Dwarf\MeiliTools\Tests\TestCase;
 use Dwarf\MeiliTools\Tests\Tools;
 
+uses(Dwarf\MeiliTools\Tests\TestCase::class);
+
 /**
  * @internal
  */
-class IndexResetTest extends TestCase
-{
-    /**
-     * Test index.
-     *
-     * @var string
-     */
-    private const INDEX = 'testing-resets-index';
 
-    /**
-     * Test `meili:index:reset` command with advanced settings.
-     */
-    public function test_with_advanced_settings(): void
-    {
-        $this->withIndex(self::INDEX, function () {
-            $defaults = Helpers::defaultSettings(Helpers::engineVersion());
-            $settings = Tools::movieSettings();
+/**
+ * Test `meili:index:reset` command with advanced settings.
+ */
+test('with advanced settings', function () {
+    $this->withIndex(self::INDEX, function () {
+        $defaults = Helpers::defaultSettings(Helpers::engineVersion());
+        $settings = Tools::movieSettings();
 
-            $this->app->make(SynchronizesIndex::class)(self::INDEX, $settings);
-            $details = $this->app->make(DetailsIndex::class)(self::INDEX);
-            $this->assertNotSame($defaults, $details);
-            $this->assertSame(array_replace($defaults, $settings), $details);
+        app()->make(SynchronizesIndex::class)(self::INDEX, $settings);
+        $details = app()->make(DetailsIndex::class)(self::INDEX);
+        $this->assertNotSame($defaults, $details);
+        $this->assertSame(array_replace($defaults, $settings), $details);
 
-            $changes = collect($settings)
-                ->mapWithKeys(function ($value, $key) {
-                    $old = $value;
-                    $new = null;
+        $changes = collect($settings)
+            ->mapWithKeys(function ($value, $key) {
+                $old = $value;
+                $new = null;
 
-                    return [$key => $old === $new ? false : compact('old', 'new')];
-                })
-                ->filter()
-                ->all()
-            ;
-            $values = Helpers::convertIndexChangesToTable($changes);
+                return [$key => $old === $new ? false : compact('old', 'new')];
+            })
+            ->filter()
+            ->all()
+        ;
+        $values = Helpers::convertIndexChangesToTable($changes);
 
-            $this->artisan('meili:index:reset', ['index' => self::INDEX])
-                ->expectsTable(['Setting', 'Old', 'New'], $values)
-                ->assertSuccessful()
-            ;
+        $this->artisan('meili:index:reset', ['index' => self::INDEX])
+            ->expectsTable(['Setting', 'Old', 'New'], $values)
+            ->assertSuccessful()
+        ;
 
-            $this->artisan('meili:index:reset')
-                ->expectsQuestion('What is the index name?', self::INDEX)
-                ->expectsTable(['Setting', 'Old', 'New'], [])
-                ->assertSuccessful()
-            ;
+        $this->artisan('meili:index:reset')
+            ->expectsQuestion('What is the index name?', self::INDEX)
+            ->expectsTable(['Setting', 'Old', 'New'], [])
+            ->assertSuccessful()
+        ;
 
-            $details = $this->app->make(DetailsIndex::class)(self::INDEX);
-            $this->assertSame($defaults, $details);
-        });
-    }
+        $details = app()->make(DetailsIndex::class)(self::INDEX);
+        $this->assertSame($defaults, $details);
+    });
+});
 
-    /**
-     * Test `meili:index:reset` command with pretend option.
-     */
-    public function test_with_pretend(): void
-    {
-        $this->withIndex(self::INDEX, function () {
-            $defaults = Helpers::defaultSettings(Helpers::engineVersion());
-            $settings = Tools::movieSettings();
+/**
+ * Test `meili:index:reset` command with pretend option.
+ */
+test('with pretend', function () {
+    $this->withIndex(self::INDEX, function () {
+        $defaults = Helpers::defaultSettings(Helpers::engineVersion());
+        $settings = Tools::movieSettings();
 
-            $this->app->make(SynchronizesIndex::class)(self::INDEX, $settings);
-            $details = $this->app->make(DetailsIndex::class)(self::INDEX);
-            $this->assertNotSame($defaults, $details);
-            $this->assertSame(array_replace($defaults, $settings), $details);
+        app()->make(SynchronizesIndex::class)(self::INDEX, $settings);
+        $details = app()->make(DetailsIndex::class)(self::INDEX);
+        $this->assertNotSame($defaults, $details);
+        $this->assertSame(array_replace($defaults, $settings), $details);
 
-            $changes = collect($settings)
-                ->mapWithKeys(function ($value, $key) {
-                    $old = $value;
-                    $new = null;
+        $changes = collect($settings)
+            ->mapWithKeys(function ($value, $key) {
+                $old = $value;
+                $new = null;
 
-                    return [$key => $old === $new ? false : compact('old', 'new')];
-                })
-                ->filter()
-                ->all()
-            ;
-            $values = Helpers::convertIndexChangesToTable($changes);
+                return [$key => $old === $new ? false : compact('old', 'new')];
+            })
+            ->filter()
+            ->all()
+        ;
+        $values = Helpers::convertIndexChangesToTable($changes);
 
-            $this->artisan('meili:index:reset', ['index' => self::INDEX, '--pretend' => true])
-                ->expectsTable(['Setting', 'Old', 'New'], $values)
-                ->assertSuccessful()
-            ;
+        $this->artisan('meili:index:reset', ['index' => self::INDEX, '--pretend' => true])
+            ->expectsTable(['Setting', 'Old', 'New'], $values)
+            ->assertSuccessful()
+        ;
 
-            $details = $this->app->make(DetailsIndex::class)(self::INDEX);
-            $this->assertNotSame($defaults, $details);
-        });
-    }
-}
+        $details = app()->make(DetailsIndex::class)(self::INDEX);
+        $this->assertNotSame($defaults, $details);
+    });
+});

--- a/tests/Commands/IndexResetTest.php
+++ b/tests/Commands/IndexResetTest.php
@@ -25,7 +25,7 @@ test('with advanced settings', function () {
         app()->make(SynchronizesIndex::class)(self::INDEX, $settings);
         $details = app()->make(DetailsIndex::class)(self::INDEX);
         $this->assertNotSame($defaults, $details);
-        $this->assertSame(array_replace($defaults, $settings), $details);
+        expect($details)->toBe(array_replace($defaults, $settings));
 
         $changes = collect($settings)
             ->mapWithKeys(function ($value, $key) {
@@ -51,7 +51,7 @@ test('with advanced settings', function () {
         ;
 
         $details = app()->make(DetailsIndex::class)(self::INDEX);
-        $this->assertSame($defaults, $details);
+        expect($details)->toBe($defaults);
     });
 });
 
@@ -66,7 +66,7 @@ test('with pretend', function () {
         app()->make(SynchronizesIndex::class)(self::INDEX, $settings);
         $details = app()->make(DetailsIndex::class)(self::INDEX);
         $this->assertNotSame($defaults, $details);
-        $this->assertSame(array_replace($defaults, $settings), $details);
+        expect($details)->toBe(array_replace($defaults, $settings));
 
         $changes = collect($settings)
             ->mapWithKeys(function ($value, $key) {

--- a/tests/Commands/IndexResetTest.php
+++ b/tests/Commands/IndexResetTest.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 use Dwarf\MeiliTools\Contracts\Actions\DetailsIndex;
 use Dwarf\MeiliTools\Contracts\Actions\SynchronizesIndex;
 use Dwarf\MeiliTools\Helpers;
-use Dwarf\MeiliTools\Tests\TestCase;
 use Dwarf\MeiliTools\Tests\Tools;
-
 
 /**
  * @internal

--- a/tests/Commands/IndexResetTest.php
+++ b/tests/Commands/IndexResetTest.php
@@ -8,7 +8,6 @@ use Dwarf\MeiliTools\Helpers;
 use Dwarf\MeiliTools\Tests\TestCase;
 use Dwarf\MeiliTools\Tests\Tools;
 
-uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal

--- a/tests/Commands/IndexViewTest.php
+++ b/tests/Commands/IndexViewTest.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use Dwarf\MeiliTools\Tests\TestCase;
 
 
 /**

--- a/tests/Commands/IndexViewTest.php
+++ b/tests/Commands/IndexViewTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Dwarf\MeiliTools\Tests\TestCase;
 
-uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal

--- a/tests/Commands/IndexViewTest.php
+++ b/tests/Commands/IndexViewTest.php
@@ -2,55 +2,44 @@
 
 declare(strict_types=1);
 
-namespace Dwarf\MeiliTools\Tests\Commands;
-
 use Dwarf\MeiliTools\Tests\TestCase;
+
+uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal
  */
-class IndexViewTest extends TestCase
-{
-    /**
-     * Test index.
-     *
-     * @var string
-     */
-    private const INDEX = 'testing-index-view';
 
-    /**
-     * Test `meili:index:view` command with default settings.
-     */
-    public function test_with_default_settings(): void
-    {
-        $this->withIndex(self::INDEX, function () {
-            // Since data returned from MeiliSearch includes microsecond precision timestamps,
-            // it's impossible to validate the exact console output.
-            $this->artisan('meili:index:view')
-                ->expectsQuestion('What is the index name?', self::INDEX)
-                // ->expectsOutputToContain(self::INDEX) - Laravel 9 only.
-                ->assertSuccessful()
-            ;
+/**
+ * Test `meili:index:view` command with default settings.
+ */
+test('with default settings', function () {
+    $this->withIndex(self::INDEX, function () {
+        // Since data returned from MeiliSearch includes microsecond precision timestamps,
+        // it's impossible to validate the exact console output.
+        $this->artisan('meili:index:view')
+            ->expectsQuestion('What is the index name?', self::INDEX)
+            // ->expectsOutputToContain(self::INDEX) - Laravel 9 only.
+            ->assertSuccessful()
+        ;
 
-            $this->artisan('meili:index:view', ['index' => self::INDEX])
-                // ->expectsOutputToContain(self::INDEX) - Laravel 9 only.
-                ->assertSuccessful()
-            ;
-        });
-    }
+        $this->artisan('meili:index:view', ['index' => self::INDEX])
+            // ->expectsOutputToContain(self::INDEX) - Laravel 9 only.
+            ->assertSuccessful()
+        ;
+    });
+});
 
-    /**
-     * Test `meili:index:view` command with stats option.
-     */
-    public function test_with_stats(): void
-    {
-        $this->withIndex(self::INDEX, function () {
-            // Since data returned from MeiliSearch includes microsecond precision timestamps,
-            // it's impossible to validate the exact console output.
-            $this->artisan('meili:index:view', ['index' => self::INDEX, '--stats' => true])
-                // ->expectsOutputToContain(self::INDEX) - Laravel 9 only.
-                ->assertSuccessful()
-            ;
-        });
-    }
-}
+/**
+ * Test `meili:index:view` command with stats option.
+ */
+test('with stats', function () {
+    $this->withIndex(self::INDEX, function () {
+        // Since data returned from MeiliSearch includes microsecond precision timestamps,
+        // it's impossible to validate the exact console output.
+        $this->artisan('meili:index:view', ['index' => self::INDEX, '--stats' => true])
+            // ->expectsOutputToContain(self::INDEX) - Laravel 9 only.
+            ->assertSuccessful()
+        ;
+    });
+});

--- a/tests/Commands/IndexesListTest.php
+++ b/tests/Commands/IndexesListTest.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use Dwarf\MeiliTools\Tests\TestCase;
 
 
 /**

--- a/tests/Commands/IndexesListTest.php
+++ b/tests/Commands/IndexesListTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Dwarf\MeiliTools\Tests\TestCase;
 
-uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal

--- a/tests/Commands/IndexesListTest.php
+++ b/tests/Commands/IndexesListTest.php
@@ -2,49 +2,38 @@
 
 declare(strict_types=1);
 
-namespace Dwarf\MeiliTools\Tests\Commands;
-
 use Dwarf\MeiliTools\Tests\TestCase;
+
+uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal
  */
-class IndexesListTest extends TestCase
-{
-    /**
-     * Test index.
-     *
-     * @var string
-     */
-    private const INDEX = 'testing-indexes-list';
 
-    /**
-     * Test `meili:indexes:list` command with default settings.
-     */
-    public function test_with_default_settings(): void
-    {
-        $this->withIndex(self::INDEX, function () {
-            // Since data returned from MeiliSearch includes microsecond precision timestamps,
-            // it's impossible to validate the exact console output.
-            $this->artisan('meili:indexes:list')
-                // ->expectsOutputToContain(self::INDEX) - Laravel 9 only.
-                ->assertSuccessful()
-            ;
-        });
-    }
+/**
+ * Test `meili:indexes:list` command with default settings.
+ */
+test('with default settings', function () {
+    $this->withIndex(self::INDEX, function () {
+        // Since data returned from MeiliSearch includes microsecond precision timestamps,
+        // it's impossible to validate the exact console output.
+        $this->artisan('meili:indexes:list')
+            // ->expectsOutputToContain(self::INDEX) - Laravel 9 only.
+            ->assertSuccessful()
+        ;
+    });
+});
 
-    /**
-     * Test `meili:indexes:list` command with stats option.
-     */
-    public function test_with_stats(): void
-    {
-        $this->withIndex(self::INDEX, function () {
-            // Since data returned from MeiliSearch includes microsecond precision timestamps,
-            // it's impossible to validate the exact console output.
-            $this->artisan('meili:indexes:list', ['--stats' => true])
-                // ->expectsOutputToContain(self::INDEX) - Laravel 9 only.
-                ->assertSuccessful()
-            ;
-        });
-    }
-}
+/**
+ * Test `meili:indexes:list` command with stats option.
+ */
+test('with stats', function () {
+    $this->withIndex(self::INDEX, function () {
+        // Since data returned from MeiliSearch includes microsecond precision timestamps,
+        // it's impossible to validate the exact console output.
+        $this->artisan('meili:indexes:list', ['--stats' => true])
+            // ->expectsOutputToContain(self::INDEX) - Laravel 9 only.
+            ->assertSuccessful()
+        ;
+    });
+});

--- a/tests/Commands/ModelDetailsTest.php
+++ b/tests/Commands/ModelDetailsTest.php
@@ -9,7 +9,6 @@ use Dwarf\MeiliTools\Tests\Models\Movie;
 use Dwarf\MeiliTools\Tests\TestCase;
 use Illuminate\Support\Arr;
 
-uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal

--- a/tests/Commands/ModelDetailsTest.php
+++ b/tests/Commands/ModelDetailsTest.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-namespace Dwarf\MeiliTools\Tests\Commands;
-
 use Dwarf\MeiliTools\Contracts\Actions\SynchronizesModel;
 use Dwarf\MeiliTools\Helpers;
 use Dwarf\MeiliTools\Tests\Models\MeiliMovie;
@@ -11,61 +9,59 @@ use Dwarf\MeiliTools\Tests\Models\Movie;
 use Dwarf\MeiliTools\Tests\TestCase;
 use Illuminate\Support\Arr;
 
+uses(Dwarf\MeiliTools\Tests\TestCase::class);
+
 /**
  * @internal
  */
-class ModelDetailsTest extends TestCase
-{
-    /**
-     * Test `meili:model:details` command with default settings.
-     */
-    public function test_with_default_settings(): void
-    {
-        try {
-            $values = Helpers::convertIndexDataToTable(Helpers::defaultSettings(Helpers::engineVersion()));
 
-            $this->artisan('meili:model:details')
-                ->expectsQuestion('What is the model class?', Movie::class)
-                ->expectsTable(['Setting', 'Value'], $values)
-                ->assertSuccessful()
-            ;
+/**
+ * Test `meili:model:details` command with default settings.
+ */
+test('with default settings', function () {
+    try {
+        $values = Helpers::convertIndexDataToTable(Helpers::defaultSettings(Helpers::engineVersion()));
 
-            $this->artisan('meili:model:details', ['model' => Movie::class])
-                ->expectsTable(['Setting', 'Value'], $values)
-                ->assertSuccessful()
-            ;
+        $this->artisan('meili:model:details')
+            ->expectsQuestion('What is the model class?', Movie::class)
+            ->expectsTable(['Setting', 'Value'], $values)
+            ->assertSuccessful()
+        ;
 
-            $this->artisan('meili:model:details', ['model' => 'Movie'])
-                ->expectsTable(['Setting', 'Value'], $values)
-                ->assertSuccessful()
-            ;
-        } finally {
-            $this->deleteIndex(app(Movie::class)->searchableAs());
-        }
+        $this->artisan('meili:model:details', ['model' => Movie::class])
+            ->expectsTable(['Setting', 'Value'], $values)
+            ->assertSuccessful()
+        ;
+
+        $this->artisan('meili:model:details', ['model' => 'Movie'])
+            ->expectsTable(['Setting', 'Value'], $values)
+            ->assertSuccessful()
+        ;
+    } finally {
+        $this->deleteIndex(app(Movie::class)->searchableAs());
     }
+});
 
-    /**
-     * Test `meili:model:details` command with advanced settings.
-     */
-    public function test_with_advanced_settings(): void
-    {
-        try {
-            $defaults = Helpers::defaultSettings(Helpers::engineVersion());
-            $settings = app(MeiliMovie::class)->meiliSettings();
+/**
+ * Test `meili:model:details` command with advanced settings.
+ */
+test('with advanced settings', function () {
+    try {
+        $defaults = Helpers::defaultSettings(Helpers::engineVersion());
+        $settings = app(MeiliMovie::class)->meiliSettings();
 
-            $changes = $this->app->make(SynchronizesModel::class)(MeiliMovie::class);
-            $this->assertNotEmpty($changes);
+        $changes = app()->make(SynchronizesModel::class)(MeiliMovie::class);
+        $this->assertNotEmpty($changes);
 
-            $values = Helpers::convertIndexDataToTable(
-                Helpers::sortSettings($settings + Arr::only($defaults, ['faceting', 'pagination', 'typoTolerance']))
-            );
+        $values = Helpers::convertIndexDataToTable(
+            Helpers::sortSettings($settings + Arr::only($defaults, ['faceting', 'pagination', 'typoTolerance']))
+        );
 
-            $this->artisan('meili:model:details', ['model' => MeiliMovie::class])
-                ->expectsTable(['Setting', 'Value'], $values)
-                ->assertSuccessful()
-            ;
-        } finally {
-            $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
-        }
+        $this->artisan('meili:model:details', ['model' => MeiliMovie::class])
+            ->expectsTable(['Setting', 'Value'], $values)
+            ->assertSuccessful()
+        ;
+    } finally {
+        $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
     }
-}
+});

--- a/tests/Commands/ModelDetailsTest.php
+++ b/tests/Commands/ModelDetailsTest.php
@@ -6,9 +6,7 @@ use Dwarf\MeiliTools\Contracts\Actions\SynchronizesModel;
 use Dwarf\MeiliTools\Helpers;
 use Dwarf\MeiliTools\Tests\Models\MeiliMovie;
 use Dwarf\MeiliTools\Tests\Models\Movie;
-use Dwarf\MeiliTools\Tests\TestCase;
 use Illuminate\Support\Arr;
-
 
 /**
  * @internal

--- a/tests/Commands/ModelResetTest.php
+++ b/tests/Commands/ModelResetTest.php
@@ -25,7 +25,7 @@ test('with advanced settings', function () {
         app()->make(SynchronizesModel::class)(MeiliMovie::class);
         $details = app()->make(DetailsModel::class)(MeiliMovie::class);
         $this->assertNotSame($defaults, $details);
-        $this->assertSame(array_replace($defaults, $settings), $details);
+        expect($details)->toBe(array_replace($defaults, $settings));
 
         $changes = collect($settings)
             ->mapWithKeys(function ($value, $key) {
@@ -57,7 +57,7 @@ test('with advanced settings', function () {
         ;
 
         $details = app()->make(DetailsModel::class)(MeiliMovie::class);
-        $this->assertSame($defaults, $details);
+        expect($details)->toBe($defaults);
     } finally {
         $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
     }
@@ -74,7 +74,7 @@ test('with pretend', function () {
         app()->make(SynchronizesModel::class)(MeiliMovie::class);
         $details = app()->make(DetailsModel::class)(MeiliMovie::class);
         $this->assertNotSame($defaults, $details);
-        $this->assertSame(array_replace($defaults, $settings), $details);
+        expect($details)->toBe(array_replace($defaults, $settings));
 
         $changes = collect($settings)
             ->mapWithKeys(function ($value, $key) {

--- a/tests/Commands/ModelResetTest.php
+++ b/tests/Commands/ModelResetTest.php
@@ -8,7 +8,6 @@ use Dwarf\MeiliTools\Helpers;
 use Dwarf\MeiliTools\Tests\Models\MeiliMovie;
 use Dwarf\MeiliTools\Tests\TestCase;
 
-uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal

--- a/tests/Commands/ModelResetTest.php
+++ b/tests/Commands/ModelResetTest.php
@@ -2,104 +2,100 @@
 
 declare(strict_types=1);
 
-namespace Dwarf\MeiliTools\Tests\Commands;
-
 use Dwarf\MeiliTools\Contracts\Actions\DetailsModel;
 use Dwarf\MeiliTools\Contracts\Actions\SynchronizesModel;
 use Dwarf\MeiliTools\Helpers;
 use Dwarf\MeiliTools\Tests\Models\MeiliMovie;
 use Dwarf\MeiliTools\Tests\TestCase;
 
+uses(Dwarf\MeiliTools\Tests\TestCase::class);
+
 /**
  * @internal
  */
-class ModelResetTest extends TestCase
-{
-    /**
-     * Test `meili:model:reset` command with advanced settings.
-     */
-    public function test_with_advanced_settings(): void
-    {
-        try {
-            $defaults = Helpers::defaultSettings(Helpers::engineVersion());
-            $settings = app(MeiliMovie::class)->meiliSettings();
 
-            $this->app->make(SynchronizesModel::class)(MeiliMovie::class);
-            $details = $this->app->make(DetailsModel::class)(MeiliMovie::class);
-            $this->assertNotSame($defaults, $details);
-            $this->assertSame(array_replace($defaults, $settings), $details);
+/**
+ * Test `meili:model:reset` command with advanced settings.
+ */
+test('with advanced settings', function () {
+    try {
+        $defaults = Helpers::defaultSettings(Helpers::engineVersion());
+        $settings = app(MeiliMovie::class)->meiliSettings();
 
-            $changes = collect($settings)
-                ->mapWithKeys(function ($value, $key) {
-                    $old = $value;
-                    $new = null;
+        app()->make(SynchronizesModel::class)(MeiliMovie::class);
+        $details = app()->make(DetailsModel::class)(MeiliMovie::class);
+        $this->assertNotSame($defaults, $details);
+        $this->assertSame(array_replace($defaults, $settings), $details);
 
-                    return [$key => $old === $new ? false : compact('old', 'new')];
-                })
-                ->filter()
-                ->all()
-            ;
-            $values = Helpers::convertIndexChangesToTable($changes);
+        $changes = collect($settings)
+            ->mapWithKeys(function ($value, $key) {
+                $old = $value;
+                $new = null;
 
-            $this->artisan('meili:model:reset', ['model' => MeiliMovie::class])
-                ->expectsTable(['Setting', 'Old', 'New'], $values)
-                ->assertSuccessful()
-            ;
+                return [$key => $old === $new ? false : compact('old', 'new')];
+            })
+            ->filter()
+            ->all()
+        ;
+        $values = Helpers::convertIndexChangesToTable($changes);
 
-            $this->artisan('meili:model:reset')
-                ->expectsQuestion('What is the model class?', MeiliMovie::class)
-                ->expectsTable(['Setting', 'Old', 'New'], [])
-                ->assertSuccessful()
-            ;
+        $this->artisan('meili:model:reset', ['model' => MeiliMovie::class])
+            ->expectsTable(['Setting', 'Old', 'New'], $values)
+            ->assertSuccessful()
+        ;
 
-            $this->artisan('meili:model:reset')
-                ->expectsQuestion('What is the model class?', 'MeiliMovie')
-                ->expectsTable(['Setting', 'Old', 'New'], [])
-                ->assertSuccessful()
-            ;
+        $this->artisan('meili:model:reset')
+            ->expectsQuestion('What is the model class?', MeiliMovie::class)
+            ->expectsTable(['Setting', 'Old', 'New'], [])
+            ->assertSuccessful()
+        ;
 
-            $details = $this->app->make(DetailsModel::class)(MeiliMovie::class);
-            $this->assertSame($defaults, $details);
-        } finally {
-            $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
-        }
+        $this->artisan('meili:model:reset')
+            ->expectsQuestion('What is the model class?', 'MeiliMovie')
+            ->expectsTable(['Setting', 'Old', 'New'], [])
+            ->assertSuccessful()
+        ;
+
+        $details = app()->make(DetailsModel::class)(MeiliMovie::class);
+        $this->assertSame($defaults, $details);
+    } finally {
+        $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
     }
+});
 
-    /**
-     * Test `meili:model:reset` command with pretend option.
-     */
-    public function test_with_pretend(): void
-    {
-        try {
-            $defaults = Helpers::defaultSettings(Helpers::engineVersion());
-            $settings = app(MeiliMovie::class)->meiliSettings();
+/**
+ * Test `meili:model:reset` command with pretend option.
+ */
+test('with pretend', function () {
+    try {
+        $defaults = Helpers::defaultSettings(Helpers::engineVersion());
+        $settings = app(MeiliMovie::class)->meiliSettings();
 
-            $this->app->make(SynchronizesModel::class)(MeiliMovie::class);
-            $details = $this->app->make(DetailsModel::class)(MeiliMovie::class);
-            $this->assertNotSame($defaults, $details);
-            $this->assertSame(array_replace($defaults, $settings), $details);
+        app()->make(SynchronizesModel::class)(MeiliMovie::class);
+        $details = app()->make(DetailsModel::class)(MeiliMovie::class);
+        $this->assertNotSame($defaults, $details);
+        $this->assertSame(array_replace($defaults, $settings), $details);
 
-            $changes = collect($settings)
-                ->mapWithKeys(function ($value, $key) {
-                    $old = $value;
-                    $new = null;
+        $changes = collect($settings)
+            ->mapWithKeys(function ($value, $key) {
+                $old = $value;
+                $new = null;
 
-                    return [$key => $old === $new ? false : compact('old', 'new')];
-                })
-                ->filter()
-                ->all()
-            ;
-            $values = Helpers::convertIndexChangesToTable($changes);
+                return [$key => $old === $new ? false : compact('old', 'new')];
+            })
+            ->filter()
+            ->all()
+        ;
+        $values = Helpers::convertIndexChangesToTable($changes);
 
-            $this->artisan('meili:model:reset', ['model' => MeiliMovie::class, '--pretend' => true])
-                ->expectsTable(['Setting', 'Old', 'New'], $values)
-                ->assertSuccessful()
-            ;
+        $this->artisan('meili:model:reset', ['model' => MeiliMovie::class, '--pretend' => true])
+            ->expectsTable(['Setting', 'Old', 'New'], $values)
+            ->assertSuccessful()
+        ;
 
-            $details = $this->app->make(DetailsModel::class)(MeiliMovie::class);
-            $this->assertNotSame($defaults, $details);
-        } finally {
-            $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
-        }
+        $details = app()->make(DetailsModel::class)(MeiliMovie::class);
+        $this->assertNotSame($defaults, $details);
+    } finally {
+        $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
     }
-}
+});

--- a/tests/Commands/ModelResetTest.php
+++ b/tests/Commands/ModelResetTest.php
@@ -6,8 +6,6 @@ use Dwarf\MeiliTools\Contracts\Actions\DetailsModel;
 use Dwarf\MeiliTools\Contracts\Actions\SynchronizesModel;
 use Dwarf\MeiliTools\Helpers;
 use Dwarf\MeiliTools\Tests\Models\MeiliMovie;
-use Dwarf\MeiliTools\Tests\TestCase;
-
 
 /**
  * @internal

--- a/tests/Commands/ModelSynchronizeTest.php
+++ b/tests/Commands/ModelSynchronizeTest.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 use Dwarf\MeiliTools\Contracts\Actions\DetailsModel;
 use Dwarf\MeiliTools\Helpers;
 use Dwarf\MeiliTools\Tests\Models\MeiliMovie;
-use Dwarf\MeiliTools\Tests\TestCase;
 use Illuminate\Support\Arr;
-
 
 /**
  * @internal

--- a/tests/Commands/ModelSynchronizeTest.php
+++ b/tests/Commands/ModelSynchronizeTest.php
@@ -8,7 +8,6 @@ use Dwarf\MeiliTools\Tests\Models\MeiliMovie;
 use Dwarf\MeiliTools\Tests\TestCase;
 use Illuminate\Support\Arr;
 
-uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal

--- a/tests/Commands/ModelSynchronizeTest.php
+++ b/tests/Commands/ModelSynchronizeTest.php
@@ -33,7 +33,7 @@ test('with advanced settings', function () {
         ;
 
         $details = app()->make(DetailsModel::class)(MeiliMovie::class);
-        $this->assertSame($defaults, $details);
+        expect($details)->toBe($defaults);
 
         $values = Helpers::convertIndexChangesToTable($changes);
 
@@ -43,7 +43,7 @@ test('with advanced settings', function () {
         ;
 
         $details = app()->make(DetailsModel::class)(MeiliMovie::class);
-        $this->assertSame($settings, Arr::except($details, ['faceting', 'pagination', 'typoTolerance']));
+        expect(Arr::except($details, ['faceting', 'pagination', 'typoTolerance']))->toBe($settings);
     } finally {
         $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
     }
@@ -68,7 +68,7 @@ test('with pretend', function () {
         ;
 
         $details = app()->make(DetailsModel::class)(MeiliMovie::class);
-        $this->assertSame($defaults, $details);
+        expect($details)->toBe($defaults);
 
         $values = Helpers::convertIndexChangesToTable($changes);
 
@@ -78,7 +78,7 @@ test('with pretend', function () {
         ;
 
         $details = app()->make(DetailsModel::class)(MeiliMovie::class);
-        $this->assertSame($defaults, $details);
+        expect($details)->toBe($defaults);
     } finally {
         $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
     }

--- a/tests/Commands/ModelSynchronizeTest.php
+++ b/tests/Commands/ModelSynchronizeTest.php
@@ -2,88 +2,84 @@
 
 declare(strict_types=1);
 
-namespace Dwarf\MeiliTools\Tests\Commands;
-
 use Dwarf\MeiliTools\Contracts\Actions\DetailsModel;
 use Dwarf\MeiliTools\Helpers;
 use Dwarf\MeiliTools\Tests\Models\MeiliMovie;
 use Dwarf\MeiliTools\Tests\TestCase;
 use Illuminate\Support\Arr;
 
+uses(Dwarf\MeiliTools\Tests\TestCase::class);
+
 /**
  * @internal
  */
-class ModelSynchronizeTest extends TestCase
-{
-    /**
-     * Test `meili:model:synchronize` command with advanced settings.
-     */
-    public function test_with_advanced_settings(): void
-    {
-        try {
-            $defaults = Helpers::defaultSettings(Helpers::engineVersion());
-            $settings = app(MeiliMovie::class)->meiliSettings();
-            $changes = collect($settings)
-                ->mapWithKeys(function ($value, $key) use ($defaults) {
-                    $old = $defaults[$key];
-                    $new = $value;
 
-                    return [$key => $old === $new ? false : compact('old', 'new')];
-                })
-                ->filter()
-                ->all()
-            ;
+/**
+ * Test `meili:model:synchronize` command with advanced settings.
+ */
+test('with advanced settings', function () {
+    try {
+        $defaults = Helpers::defaultSettings(Helpers::engineVersion());
+        $settings = app(MeiliMovie::class)->meiliSettings();
+        $changes = collect($settings)
+            ->mapWithKeys(function ($value, $key) use ($defaults) {
+                $old = $defaults[$key];
+                $new = $value;
 
-            $details = $this->app->make(DetailsModel::class)(MeiliMovie::class);
-            $this->assertSame($defaults, $details);
+                return [$key => $old === $new ? false : compact('old', 'new')];
+            })
+            ->filter()
+            ->all()
+        ;
 
-            $values = Helpers::convertIndexChangesToTable($changes);
+        $details = app()->make(DetailsModel::class)(MeiliMovie::class);
+        $this->assertSame($defaults, $details);
 
-            $this->artisan('meili:model:synchronize', ['model' => MeiliMovie::class])
-                ->expectsTable(['Setting', 'Old', 'New'], $values)
-                ->assertSuccessful()
-            ;
+        $values = Helpers::convertIndexChangesToTable($changes);
 
-            $details = $this->app->make(DetailsModel::class)(MeiliMovie::class);
-            $this->assertSame($settings, Arr::except($details, ['faceting', 'pagination', 'typoTolerance']));
-        } finally {
-            $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
-        }
+        $this->artisan('meili:model:synchronize', ['model' => MeiliMovie::class])
+            ->expectsTable(['Setting', 'Old', 'New'], $values)
+            ->assertSuccessful()
+        ;
+
+        $details = app()->make(DetailsModel::class)(MeiliMovie::class);
+        $this->assertSame($settings, Arr::except($details, ['faceting', 'pagination', 'typoTolerance']));
+    } finally {
+        $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
     }
+});
 
-    /**
-     * Test `meili:model:synchronize` command with pretend option.
-     */
-    public function test_with_pretend(): void
-    {
-        try {
-            $defaults = Helpers::defaultSettings(Helpers::engineVersion());
-            $settings = app(MeiliMovie::class)->meiliSettings();
-            $changes = collect($settings)
-                ->mapWithKeys(function ($value, $key) use ($defaults) {
-                    $old = $defaults[$key];
-                    $new = $value;
+/**
+ * Test `meili:model:synchronize` command with pretend option.
+ */
+test('with pretend', function () {
+    try {
+        $defaults = Helpers::defaultSettings(Helpers::engineVersion());
+        $settings = app(MeiliMovie::class)->meiliSettings();
+        $changes = collect($settings)
+            ->mapWithKeys(function ($value, $key) use ($defaults) {
+                $old = $defaults[$key];
+                $new = $value;
 
-                    return [$key => $old === $new ? false : compact('old', 'new')];
-                })
-                ->filter()
-                ->all()
-            ;
+                return [$key => $old === $new ? false : compact('old', 'new')];
+            })
+            ->filter()
+            ->all()
+        ;
 
-            $details = $this->app->make(DetailsModel::class)(MeiliMovie::class);
-            $this->assertSame($defaults, $details);
+        $details = app()->make(DetailsModel::class)(MeiliMovie::class);
+        $this->assertSame($defaults, $details);
 
-            $values = Helpers::convertIndexChangesToTable($changes);
+        $values = Helpers::convertIndexChangesToTable($changes);
 
-            $this->artisan('meili:model:synchronize', ['model' => MeiliMovie::class, '--pretend' => true])
-                ->expectsTable(['Setting', 'Old', 'New'], $values)
-                ->assertSuccessful()
-            ;
+        $this->artisan('meili:model:synchronize', ['model' => MeiliMovie::class, '--pretend' => true])
+            ->expectsTable(['Setting', 'Old', 'New'], $values)
+            ->assertSuccessful()
+        ;
 
-            $details = $this->app->make(DetailsModel::class)(MeiliMovie::class);
-            $this->assertSame($defaults, $details);
-        } finally {
-            $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
-        }
+        $details = app()->make(DetailsModel::class)(MeiliMovie::class);
+        $this->assertSame($defaults, $details);
+    } finally {
+        $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
     }
-}
+});

--- a/tests/Commands/ModelViewTest.php
+++ b/tests/Commands/ModelViewTest.php
@@ -2,62 +2,58 @@
 
 declare(strict_types=1);
 
-namespace Dwarf\MeiliTools\Tests\Commands;
-
 use Dwarf\MeiliTools\Tests\Models\Movie;
 use Dwarf\MeiliTools\Tests\TestCase;
+
+uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal
  */
-class ModelViewTest extends TestCase
-{
-    /**
-     * Test `meili:model:view` command with default settings.
-     */
-    public function test_with_default_settings(): void
-    {
-        $index = app(Movie::class)->searchableAs();
 
-        try {
-            // Since data returned from MeiliSearch includes microsecond precision timestamps,
-            // it's impossible to validate the exact console output.
-            $this->artisan('meili:model:view')
-                ->expectsQuestion('What is the model class?', Movie::class)
-                // ->expectsOutputToContain($index) - Laravel 9 only.
-                ->assertSuccessful()
-            ;
+/**
+ * Test `meili:model:view` command with default settings.
+ */
+test('with default settings', function () {
+    $index = app(Movie::class)->searchableAs();
 
-            $this->artisan('meili:model:view', ['model' => Movie::class])
-                // ->expectsOutputToContain($index) - Laravel 9 only.
-                ->assertSuccessful()
-            ;
+    try {
+        // Since data returned from MeiliSearch includes microsecond precision timestamps,
+        // it's impossible to validate the exact console output.
+        $this->artisan('meili:model:view')
+            ->expectsQuestion('What is the model class?', Movie::class)
+            // ->expectsOutputToContain($index) - Laravel 9 only.
+            ->assertSuccessful()
+        ;
 
-            $this->artisan('meili:model:view', ['model' => 'Movie'])
-                // ->expectsOutputToContain($index) - Laravel 9 only.
-                ->assertSuccessful()
-            ;
-        } finally {
-            $this->deleteIndex($index);
-        }
+        $this->artisan('meili:model:view', ['model' => Movie::class])
+            // ->expectsOutputToContain($index) - Laravel 9 only.
+            ->assertSuccessful()
+        ;
+
+        $this->artisan('meili:model:view', ['model' => 'Movie'])
+            // ->expectsOutputToContain($index) - Laravel 9 only.
+            ->assertSuccessful()
+        ;
+    } finally {
+        $this->deleteIndex($index);
     }
+});
 
-    /**
-     * Test `meili:model:view` command with stats option.
-     */
-    public function test_with_stats(): void
-    {
-        $index = app(Movie::class)->searchableAs();
+/**
+ * Test `meili:model:view` command with stats option.
+ */
+test('with stats', function () {
+    $index = app(Movie::class)->searchableAs();
 
-        try {
-            // Since data returned from MeiliSearch includes microsecond precision timestamps,
-            // it's impossible to validate the exact console output.
-            $this->artisan('meili:model:view', ['model' => Movie::class, '--stats' => true])
-                // ->expectsOutputToContain($index) - Laravel 9 only.
-                ->assertSuccessful()
-            ;
-        } finally {
-            $this->deleteIndex($index);
-        }
+    try {
+        // Since data returned from MeiliSearch includes microsecond precision timestamps,
+        // it's impossible to validate the exact console output.
+        $this->artisan('meili:model:view', ['model' => Movie::class, '--stats' => true])
+            // ->expectsOutputToContain($index) - Laravel 9 only.
+            ->assertSuccessful()
+        ;
+    } finally {
+        $this->deleteIndex($index);
     }
-}
+});

--- a/tests/Commands/ModelViewTest.php
+++ b/tests/Commands/ModelViewTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 use Dwarf\MeiliTools\Tests\Models\Movie;
 use Dwarf\MeiliTools\Tests\TestCase;
 
-uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal

--- a/tests/Commands/ModelViewTest.php
+++ b/tests/Commands/ModelViewTest.php
@@ -3,8 +3,6 @@
 declare(strict_types=1);
 
 use Dwarf\MeiliTools\Tests\Models\Movie;
-use Dwarf\MeiliTools\Tests\TestCase;
-
 
 /**
  * @internal

--- a/tests/Commands/ModelsSynchronizeTest.php
+++ b/tests/Commands/ModelsSynchronizeTest.php
@@ -37,7 +37,7 @@ test('with advanced settings', function () {
         $values = Helpers::convertIndexChangesToTable($changes);
 
         $details = app()->make(DetailsModel::class)(MeiliMovie::class);
-        $this->assertSame($defaults, $details);
+        expect($details)->toBe($defaults);
 
         $version = app()->version();
         $message = 'The distinct attribute field must be a string.';
@@ -57,7 +57,7 @@ test('with advanced settings', function () {
         ;
 
         $details = app()->make(DetailsModel::class)(MeiliMovie::class);
-        $this->assertSame($settings, Arr::except($details, ['faceting', 'pagination', 'typoTolerance']));
+        expect(Arr::except($details, ['faceting', 'pagination', 'typoTolerance']))->toBe($settings);
     } finally {
         $this->deleteIndex(app(BrokenMovie::class)->searchableAs());
         $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
@@ -84,7 +84,7 @@ test('with pretend', function () {
         $values = Helpers::convertIndexChangesToTable($changes);
 
         $details = app()->make(DetailsModel::class)(MeiliMovie::class);
-        $this->assertSame($defaults, $details);
+        expect($details)->toBe($defaults);
 
         $path = __DIR__ . '/../Models';
         $namespace = 'Dwarf\\MeiliTools\\Tests\\Models';
@@ -108,7 +108,7 @@ test('with pretend', function () {
         ;
 
         $details = app()->make(DetailsModel::class)(MeiliMovie::class);
-        $this->assertSame($defaults, $details);
+        expect($details)->toBe($defaults);
     } finally {
         $this->deleteIndex(app(BrokenMovie::class)->searchableAs());
         $this->deleteIndex(app(MeiliMovie::class)->searchableAs());

--- a/tests/Commands/ModelsSynchronizeTest.php
+++ b/tests/Commands/ModelsSynchronizeTest.php
@@ -6,11 +6,9 @@ use Dwarf\MeiliTools\Contracts\Actions\DetailsModel;
 use Dwarf\MeiliTools\Helpers;
 use Dwarf\MeiliTools\Tests\Models\BrokenMovie;
 use Dwarf\MeiliTools\Tests\Models\MeiliMovie;
-use Dwarf\MeiliTools\Tests\TestCase;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\App;
 use Illuminate\Validation\ValidationException;
-
 
 /**
  * @internal

--- a/tests/Commands/ModelsSynchronizeTest.php
+++ b/tests/Commands/ModelsSynchronizeTest.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-namespace Dwarf\MeiliTools\Tests\Commands;
-
 use Dwarf\MeiliTools\Contracts\Actions\DetailsModel;
 use Dwarf\MeiliTools\Helpers;
 use Dwarf\MeiliTools\Tests\Models\BrokenMovie;
@@ -13,135 +11,132 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\App;
 use Illuminate\Validation\ValidationException;
 
+uses(Dwarf\MeiliTools\Tests\TestCase::class);
+
 /**
  * @internal
  */
-class ModelsSynchronizeTest extends TestCase
-{
-    /**
-     * Test `meili:models:synchronize` command.
-     */
-    public function test_with_advanced_settings(): void
-    {
-        try {
-            $defaults = Helpers::defaultSettings(Helpers::engineVersion());
-            $settings = app(MeiliMovie::class)->meiliSettings();
-            $changes = collect($settings)
-                ->mapWithKeys(function ($value, $key) use ($defaults) {
-                    $old = $defaults[$key];
-                    $new = $value;
 
-                    return [$key => $old === $new ? false : compact('old', 'new')];
-                })
-                ->filter()
-                ->all()
-            ;
-            $values = Helpers::convertIndexChangesToTable($changes);
+/**
+ * Test `meili:models:synchronize` command.
+ */
+test('with advanced settings', function () {
+    try {
+        $defaults = Helpers::defaultSettings(Helpers::engineVersion());
+        $settings = app(MeiliMovie::class)->meiliSettings();
+        $changes = collect($settings)
+            ->mapWithKeys(function ($value, $key) use ($defaults) {
+                $old = $defaults[$key];
+                $new = $value;
 
-            $details = $this->app->make(DetailsModel::class)(MeiliMovie::class);
-            $this->assertSame($defaults, $details);
+                return [$key => $old === $new ? false : compact('old', 'new')];
+            })
+            ->filter()
+            ->all()
+        ;
+        $values = Helpers::convertIndexChangesToTable($changes);
 
-            $version = app()->version();
-            $message = 'The distinct attribute field must be a string.';
-            if (version_compare($version, '10.0.0', '<')) {
-                $message = 'The distinct attribute must be a string.';
-            }
-            if (version_compare($version, '9.0.0', '<')) {
-                $message = 'The given data was invalid.';
-            }
+        $details = app()->make(DetailsModel::class)(MeiliMovie::class);
+        $this->assertSame($defaults, $details);
 
-            $this->artisan('meili:models:synchronize')
-                ->expectsOutput('Processed ' . BrokenMovie::class)
-                ->expectsOutput(sprintf("Exception '%s' with message '%s'", ValidationException::class, $message))
-                ->expectsOutput('Processed ' . MeiliMovie::class)
-                ->expectsTable(['Setting', 'Old', 'New'], $values)
-                ->assertSuccessful()
-            ;
-
-            $details = $this->app->make(DetailsModel::class)(MeiliMovie::class);
-            $this->assertSame($settings, Arr::except($details, ['faceting', 'pagination', 'typoTolerance']));
-        } finally {
-            $this->deleteIndex(app(BrokenMovie::class)->searchableAs());
-            $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
+        $version = app()->version();
+        $message = 'The distinct attribute field must be a string.';
+        if (version_compare($version, '10.0.0', '<')) {
+            $message = 'The distinct attribute must be a string.';
         }
-    }
-
-    /**
-     * Test `meili:models:synchronize` command with pretend option.
-     */
-    public function test_with_pretend(): void
-    {
-        try {
-            $defaults = Helpers::defaultSettings(Helpers::engineVersion());
-            $settings = app(MeiliMovie::class)->meiliSettings();
-            $changes = collect($settings)
-                ->mapWithKeys(function ($value, $key) use ($defaults) {
-                    $old = $defaults[$key];
-                    $new = $value;
-
-                    return [$key => $old === $new ? false : compact('old', 'new')];
-                })
-                ->filter()
-                ->all()
-            ;
-            $values = Helpers::convertIndexChangesToTable($changes);
-
-            $details = $this->app->make(DetailsModel::class)(MeiliMovie::class);
-            $this->assertSame($defaults, $details);
-
-            $path = __DIR__ . '/../Models';
-            $namespace = 'Dwarf\\MeiliTools\\Tests\\Models';
-            config(['meilitools.paths' => [$path => $namespace]]);
-
-            $version = app()->version();
-            $message = 'The distinct attribute field must be a string.';
-            if (version_compare($version, '10.0.0', '<')) {
-                $message = 'The distinct attribute must be a string.';
-            }
-            if (version_compare($version, '9.0.0', '<')) {
-                $message = 'The given data was invalid.';
-            }
-
-            $this->artisan('meili:models:synchronize', ['--pretend' => true])
-                ->expectsOutput('Processed ' . BrokenMovie::class)
-                ->expectsOutput(sprintf("Exception '%s' with message '%s'", ValidationException::class, $message))
-                ->expectsOutput('Processed ' . MeiliMovie::class)
-                ->expectsTable(['Setting', 'Old', 'New'], $values)
-                ->assertSuccessful()
-            ;
-
-            $details = $this->app->make(DetailsModel::class)(MeiliMovie::class);
-            $this->assertSame($defaults, $details);
-        } finally {
-            $this->deleteIndex(app(BrokenMovie::class)->searchableAs());
-            $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
+        if (version_compare($version, '9.0.0', '<')) {
+            $message = 'The given data was invalid.';
         }
+
+        $this->artisan('meili:models:synchronize')
+            ->expectsOutput('Processed ' . BrokenMovie::class)
+            ->expectsOutput(sprintf("Exception '%s' with message '%s'", ValidationException::class, $message))
+            ->expectsOutput('Processed ' . MeiliMovie::class)
+            ->expectsTable(['Setting', 'Old', 'New'], $values)
+            ->assertSuccessful()
+        ;
+
+        $details = app()->make(DetailsModel::class)(MeiliMovie::class);
+        $this->assertSame($settings, Arr::except($details, ['faceting', 'pagination', 'typoTolerance']));
+    } finally {
+        $this->deleteIndex(app(BrokenMovie::class)->searchableAs());
+        $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
     }
+});
 
-    /**
-     * Test `meili:models:synchronize` command in production mode.
-     */
-    public function test_in_production_mode(): void
-    {
-        App::detectEnvironment(fn () => 'production');
+/**
+ * Test `meili:models:synchronize` command with pretend option.
+ */
+test('with pretend', function () {
+    try {
+        $defaults = Helpers::defaultSettings(Helpers::engineVersion());
+        $settings = app(MeiliMovie::class)->meiliSettings();
+        $changes = collect($settings)
+            ->mapWithKeys(function ($value, $key) use ($defaults) {
+                $old = $defaults[$key];
+                $new = $value;
 
-        try {
-            $this->artisan('meili:models:synchronize')
-                ->expectsConfirmation('Are you sure you want to run this command?', 'no')
-                ->assertFailed()
-            ;
+                return [$key => $old === $new ? false : compact('old', 'new')];
+            })
+            ->filter()
+            ->all()
+        ;
+        $values = Helpers::convertIndexChangesToTable($changes);
 
-            $this->artisan('meili:models:synchronize', ['--force' => true])
-                ->assertSuccessful()
-            ;
+        $details = app()->make(DetailsModel::class)(MeiliMovie::class);
+        $this->assertSame($defaults, $details);
 
-            $this->artisan('meili:models:synchronize')
-                ->expectsConfirmation('Are you sure you want to run this command?', 'yes')
-                ->assertSuccessful()
-            ;
-        } finally {
-            $this->deleteIndex(app(BrokenMovie::class)->searchableAs());
-            $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
+        $path = __DIR__ . '/../Models';
+        $namespace = 'Dwarf\\MeiliTools\\Tests\\Models';
+        config(['meilitools.paths' => [$path => $namespace]]);
+
+        $version = app()->version();
+        $message = 'The distinct attribute field must be a string.';
+        if (version_compare($version, '10.0.0', '<')) {
+            $message = 'The distinct attribute must be a string.';
         }
+        if (version_compare($version, '9.0.0', '<')) {
+            $message = 'The given data was invalid.';
+        }
+
+        $this->artisan('meili:models:synchronize', ['--pretend' => true])
+            ->expectsOutput('Processed ' . BrokenMovie::class)
+            ->expectsOutput(sprintf("Exception '%s' with message '%s'", ValidationException::class, $message))
+            ->expectsOutput('Processed ' . MeiliMovie::class)
+            ->expectsTable(['Setting', 'Old', 'New'], $values)
+            ->assertSuccessful()
+        ;
+
+        $details = app()->make(DetailsModel::class)(MeiliMovie::class);
+        $this->assertSame($defaults, $details);
+    } finally {
+        $this->deleteIndex(app(BrokenMovie::class)->searchableAs());
+        $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
     }
-}
+});
+
+/**
+ * Test `meili:models:synchronize` command in production mode.
+ */
+test('in production mode', function () {
+    App::detectEnvironment(fn () => 'production');
+
+    try {
+        $this->artisan('meili:models:synchronize')
+            ->expectsConfirmation('Are you sure you want to run this command?', 'no')
+            ->assertFailed()
+        ;
+
+        $this->artisan('meili:models:synchronize', ['--force' => true])
+            ->assertSuccessful()
+        ;
+
+        $this->artisan('meili:models:synchronize')
+            ->expectsConfirmation('Are you sure you want to run this command?', 'yes')
+            ->assertSuccessful()
+        ;
+    } finally {
+        $this->deleteIndex(app(BrokenMovie::class)->searchableAs());
+        $this->deleteIndex(app(MeiliMovie::class)->searchableAs());
+    }
+});

--- a/tests/Commands/ModelsSynchronizeTest.php
+++ b/tests/Commands/ModelsSynchronizeTest.php
@@ -11,7 +11,6 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\App;
 use Illuminate\Validation\ValidationException;
 
-uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Test Case
+|--------------------------------------------------------------------------
+|
+| The closure you provide to your test functions is always bound to a specific PHPUnit test
+| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
+| need to change it using the "uses()" function to bind a different classes or traits.
+|
+*/
+
+/** @link https://pestphp.com/docs/configuring-tests */
+
+/*
+|--------------------------------------------------------------------------
+| Expectations
+|--------------------------------------------------------------------------
+|
+| When you're writing tests, you often need to check that values meet certain conditions. The
+| "expect()" function gives you access to a set of "expectations" methods that you can use
+| to assert different things. Of course, you may extend the Expectation API at any time.
+|
+*/
+
+/** @link https://pestphp.com/docs/custom-expectations */
+
+/*
+|--------------------------------------------------------------------------
+| Functions
+|--------------------------------------------------------------------------
+|
+| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
+| project that you don't want to repeat in every file. Here you can also expose helpers as
+| global functions to help you to reduce the number of lines of code in your test files.
+|
+*/
+
+/** @link https://pestphp.com/docs/custom-helpers */

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,7 @@
 <?php
 
+uses(\Dwarf\MeiliTools\Tests\TestCase::class)->in('Actions', 'Commands', 'Models', 'Support');
+
 /*
 |--------------------------------------------------------------------------
 | Test Case

--- a/tests/Support/HelpersTest.php
+++ b/tests/Support/HelpersTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 use Dwarf\MeiliTools\Helpers;
 use Dwarf\MeiliTools\Tests\Models\Movie;
-use Dwarf\MeiliTools\Tests\TestCase;
-
 
 /**
  * @internal

--- a/tests/Support/HelpersTest.php
+++ b/tests/Support/HelpersTest.php
@@ -2,24 +2,21 @@
 
 declare(strict_types=1);
 
-namespace Dwarf\MeiliTools\Tests\Support;
-
 use Dwarf\MeiliTools\Helpers;
 use Dwarf\MeiliTools\Tests\Models\Movie;
 use Dwarf\MeiliTools\Tests\TestCase;
 
+uses(Dwarf\MeiliTools\Tests\TestCase::class);
+
 /**
  * @internal
  */
-class HelpersTest extends TestCase
-{
-    /**
-     * Test Helpers::guessModelNamespace() method.
-     */
-    public function test_guess_model_namespace(): void
-    {
-        $this->assertSame(Movie::class, Helpers::guessModelNamespace(Movie::class));
-        $this->assertSame(Movie::class, Helpers::guessModelNamespace('Movie'));
-        $this->assertSame('Fake', Helpers::guessModelNamespace('Fake'));
-    }
-}
+
+/**
+ * Test Helpers::guessModelNamespace() method.
+ */
+test('guess model namespace', function () {
+    $this->assertSame(Movie::class, Helpers::guessModelNamespace(Movie::class));
+    $this->assertSame(Movie::class, Helpers::guessModelNamespace('Movie'));
+    $this->assertSame('Fake', Helpers::guessModelNamespace('Fake'));
+});

--- a/tests/Support/HelpersTest.php
+++ b/tests/Support/HelpersTest.php
@@ -6,7 +6,6 @@ use Dwarf\MeiliTools\Helpers;
 use Dwarf\MeiliTools\Tests\Models\Movie;
 use Dwarf\MeiliTools\Tests\TestCase;
 
-uses(Dwarf\MeiliTools\Tests\TestCase::class);
 
 /**
  * @internal

--- a/tests/Support/HelpersTest.php
+++ b/tests/Support/HelpersTest.php
@@ -16,7 +16,7 @@ uses(Dwarf\MeiliTools\Tests\TestCase::class);
  * Test Helpers::guessModelNamespace() method.
  */
 test('guess model namespace', function () {
-    $this->assertSame(Movie::class, Helpers::guessModelNamespace(Movie::class));
-    $this->assertSame(Movie::class, Helpers::guessModelNamespace('Movie'));
-    $this->assertSame('Fake', Helpers::guessModelNamespace('Fake'));
+    expect(Helpers::guessModelNamespace(Movie::class))->toBe(Movie::class);
+    expect(Helpers::guessModelNamespace('Movie'))->toBe(Movie::class);
+    expect(Helpers::guessModelNamespace('Fake'))->toBe('Fake');
 });


### PR DESCRIPTION
This pull request contains changes for migrating your test suite from PHPUnit to [Pest](https://pestphp.com/) automated by the [Pest Converter](https://laravelshift.com/phpunit-to-pest-converter).

**Before merging**, you need to:

- Checkout the `shift-156398` branch
- Review **all** of the comments below for additional changes
- Run `composer update` to install Pest with your dependencies
- Run `vendor/bin/pest` to verify the conversion
